### PR TITLE
Erc3k & Create: .gitignore files updated

### DIFF
--- a/packages/erc3k/.gitignore
+++ b/packages/erc3k/.gitignore
@@ -6,3 +6,6 @@ abi
 artifacts
 cache
 typechain
+
+coverage/
+coverage.json

--- a/packages/govern-create/.gitignore
+++ b/packages/govern-create/.gitignore
@@ -4,3 +4,6 @@ yarn-error.log
 #Buidler files
 cache
 artifacts
+
+coverage/
+coverage.json


### PR DESCRIPTION
- added ``coverage/`` and ``coverage.json`` to the ``.gitignore`` file of the ``erc3k`` and ``govern-create`` package