### PR TITLE
CI: fix ERC3000Mock typo

### DIFF
--- a/packages/govern-core/test/govern-registry.test.ts
+++ b/packages/govern-core/test/govern-registry.test.ts
@@ -33,7 +33,7 @@ describe('GovernRegistry', function () {
 
   beforeEach(async () => {
     const ERC3000Mock = (await ethers.getContractFactory(
-      'Erc3000Mock'
+      'ERC3000Mock'
     )) as Erc3000MockFactory
 
     const ERC3000ExecutorMock = (await ethers.getContractFactory(


### PR DESCRIPTION
Probably worked for you locally because you have cached contract with typoed name :)