### PR TITLE
Console: Update queries and ABIs to reflect latest changes

### DIFF
--- a/packages/govern-console/src/components/NewAction.tsx
+++ b/packages/govern-console/src/components/NewAction.tsx
@@ -259,10 +259,6 @@ function ContractCallHandler({
                 token: config.challengeDeposit.token.id,
                 amount: config.challengeDeposit.amount,
               },
-              vetoDeposit: {
-                token: config.vetoDeposit.token.id,
-                amount: config.vetoDeposit.amount,
-              },
               resolver: config.resolver,
               rules: config.rules,
             },

--- a/packages/govern-console/src/index.tsx
+++ b/packages/govern-console/src/index.tsx
@@ -11,10 +11,15 @@ import {
 import App from './App'
 import GeneralProvider from './Providers/GeneralProvider'
 
-const client: ApolloClient<NormalizedCacheObject> = new ApolloClient({
-  uri: process.env.REACT_APP_SUBGRAPH_URL,
+export const rinkebyClient: ApolloClient<NormalizedCacheObject> = new ApolloClient({
+  uri: 'https://api.thegraph.com/subgraphs/name/aragon/aragon-govern-rinkeby',
   cache: new InMemoryCache()
 });
+
+export const mainnetClient: ApolloClient<NormalizedCacheObject> = new ApolloClient({
+  uri: 'https://api.thegraph.com/subgraphs/name/aragon/aragon-govern-rinkeby',
+  cache: new InMemoryCache()
+})
 
 const GlobalStyle = createGlobalStyle`
   *, *:before, *:after {
@@ -56,7 +61,7 @@ const GlobalStyle = createGlobalStyle`
 `
 
 render(
-  <ApolloProvider client={client}>
+  <ApolloProvider client={rinkebyClient}>
     <GeneralProvider>
       <React.StrictMode>
         <GlobalStyle />

--- a/packages/govern-console/src/lib/abi/Govern.json
+++ b/packages/govern-console/src/lib/abi/Govern.json
@@ -2,7 +2,7 @@
   {
     "inputs": [
       {
-        "internalType": "contract ERC3000",
+        "internalType": "address",
         "name": "_initialExecutor",
         "type": "address"
       }
@@ -132,6 +132,70 @@
     "inputs": [
       {
         "indexed": true,
+        "internalType": "string",
+        "name": "key",
+        "type": "string"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes4",
+        "name": "sig",
+        "type": "bytes4"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "ReceivedCallback",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes4",
+        "name": "sig",
+        "type": "bytes4"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes4",
+        "name": "magicNumber",
+        "type": "bytes4"
+      }
+    ],
+    "name": "RegisteredCallback",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "RegisteredStandard",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
         "internalType": "bytes4",
         "name": "role",
         "type": "bytes4"
@@ -151,6 +215,10 @@
     ],
     "name": "Revoked",
     "type": "event"
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "fallback"
   },
   {
     "inputs": [],
@@ -280,6 +348,38 @@
   {
     "inputs": [
       {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "name": "initBlocks",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_initialExecutor",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bytes4",
         "name": "_role",
         "type": "bytes4"
@@ -294,6 +394,29 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "_interfaceId",
+        "type": "bytes4"
+      },
+      {
+        "internalType": "bytes4",
+        "name": "_callbackSig",
+        "type": "bytes4"
+      },
+      {
+        "internalType": "bytes4",
+        "name": "_magicNumber",
+        "type": "bytes4"
+      }
+    ],
+    "name": "registerStandardAndCallback",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -354,7 +477,7 @@
         "type": "bool"
       }
     ],
-    "stateMutability": "pure",
+    "stateMutability": "view",
     "type": "function"
   },
   {

--- a/packages/govern-console/src/lib/abi/GovernQueue.json
+++ b/packages/govern-console/src/lib/abi/GovernQueue.json
@@ -48,23 +48,6 @@
             "type": "tuple"
           },
           {
-            "components": [
-              {
-                "internalType": "address",
-                "name": "token",
-                "type": "address"
-              },
-              {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-              }
-            ],
-            "internalType": "struct ERC3000Data.Collateral",
-            "name": "vetoDeposit",
-            "type": "tuple"
-          },
-          {
             "internalType": "address",
             "name": "resolver",
             "type": "address"
@@ -189,23 +172,6 @@
             "type": "tuple"
           },
           {
-            "components": [
-              {
-                "internalType": "address",
-                "name": "token",
-                "type": "address"
-              },
-              {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-              }
-            ],
-            "internalType": "struct ERC3000Data.Collateral",
-            "name": "vetoDeposit",
-            "type": "tuple"
-          },
-          {
             "internalType": "address",
             "name": "resolver",
             "type": "address"
@@ -323,6 +289,70 @@
       }
     ],
     "name": "Granted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "string",
+        "name": "key",
+        "type": "string"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes4",
+        "name": "sig",
+        "type": "bytes4"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "ReceivedCallback",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes4",
+        "name": "sig",
+        "type": "bytes4"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes4",
+        "name": "magicNumber",
+        "type": "bytes4"
+      }
+    ],
+    "name": "RegisteredCallback",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "RegisteredStandard",
     "type": "event"
   },
   {
@@ -511,24 +541,6 @@
         "internalType": "bytes",
         "name": "reason",
         "type": "bytes"
-      },
-      {
-        "components": [
-          {
-            "internalType": "address",
-            "name": "token",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "amount",
-            "type": "uint256"
-          }
-        ],
-        "indexed": false,
-        "internalType": "struct ERC3000Data.Collateral",
-        "name": "collateral",
-        "type": "tuple"
       }
     ],
     "name": "Vetoed",
@@ -682,23 +694,6 @@
                 "type": "tuple"
               },
               {
-                "components": [
-                  {
-                    "internalType": "address",
-                    "name": "token",
-                    "type": "address"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                  }
-                ],
-                "internalType": "struct ERC3000Data.Collateral",
-                "name": "vetoDeposit",
-                "type": "tuple"
-              },
-              {
                 "internalType": "address",
                 "name": "resolver",
                 "type": "address"
@@ -808,23 +803,6 @@
             ],
             "internalType": "struct ERC3000Data.Collateral",
             "name": "challengeDeposit",
-            "type": "tuple"
-          },
-          {
-            "components": [
-              {
-                "internalType": "address",
-                "name": "token",
-                "type": "address"
-              },
-              {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-              }
-            ],
-            "internalType": "struct ERC3000Data.Collateral",
-            "name": "vetoDeposit",
             "type": "tuple"
           },
           {
@@ -983,23 +961,6 @@
                 "type": "tuple"
               },
               {
-                "components": [
-                  {
-                    "internalType": "address",
-                    "name": "token",
-                    "type": "address"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                  }
-                ],
-                "internalType": "struct ERC3000Data.Collateral",
-                "name": "vetoDeposit",
-                "type": "tuple"
-              },
-              {
                 "internalType": "address",
                 "name": "resolver",
                 "type": "address"
@@ -1141,23 +1102,6 @@
                 "type": "tuple"
               },
               {
-                "components": [
-                  {
-                    "internalType": "address",
-                    "name": "token",
-                    "type": "address"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                  }
-                ],
-                "internalType": "struct ERC3000Data.Collateral",
-                "name": "vetoDeposit",
-                "type": "tuple"
-              },
-              {
                 "internalType": "address",
                 "name": "resolver",
                 "type": "address"
@@ -1221,6 +1165,94 @@
       }
     ],
     "name": "grant",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "name": "initBlocks",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_aclRoot",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "executionDelay",
+            "type": "uint256"
+          },
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "token",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ERC3000Data.Collateral",
+            "name": "scheduleDeposit",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "token",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ERC3000Data.Collateral",
+            "name": "challengeDeposit",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address",
+            "name": "resolver",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "rules",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct ERC3000Data.Config",
+        "name": "_initialConfig",
+        "type": "tuple"
+      }
+    ],
+    "name": "initialize",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -1378,23 +1410,6 @@
                 ],
                 "internalType": "struct ERC3000Data.Collateral",
                 "name": "challengeDeposit",
-                "type": "tuple"
-              },
-              {
-                "components": [
-                  {
-                    "internalType": "address",
-                    "name": "token",
-                    "type": "address"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                  }
-                ],
-                "internalType": "struct ERC3000Data.Collateral",
-                "name": "vetoDeposit",
                 "type": "tuple"
               },
               {
@@ -1604,23 +1619,6 @@
                 "type": "tuple"
               },
               {
-                "components": [
-                  {
-                    "internalType": "address",
-                    "name": "token",
-                    "type": "address"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                  }
-                ],
-                "internalType": "struct ERC3000Data.Collateral",
-                "name": "vetoDeposit",
-                "type": "tuple"
-              },
-              {
                 "internalType": "address",
                 "name": "resolver",
                 "type": "address"
@@ -1757,23 +1755,6 @@
                 "type": "tuple"
               },
               {
-                "components": [
-                  {
-                    "internalType": "address",
-                    "name": "token",
-                    "type": "address"
-                  },
-                  {
-                    "internalType": "uint256",
-                    "name": "amount",
-                    "type": "uint256"
-                  }
-                ],
-                "internalType": "struct ERC3000Data.Collateral",
-                "name": "vetoDeposit",
-                "type": "tuple"
-              },
-              {
                 "internalType": "address",
                 "name": "resolver",
                 "type": "address"
@@ -1838,88 +1819,15 @@
         "type": "bool"
       }
     ],
-    "stateMutability": "pure",
+    "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
       {
         "internalType": "bytes32",
-        "name": "_payloadHash",
+        "name": "_containerHash",
         "type": "bytes32"
-      },
-      {
-        "components": [
-          {
-            "internalType": "uint256",
-            "name": "executionDelay",
-            "type": "uint256"
-          },
-          {
-            "components": [
-              {
-                "internalType": "address",
-                "name": "token",
-                "type": "address"
-              },
-              {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-              }
-            ],
-            "internalType": "struct ERC3000Data.Collateral",
-            "name": "scheduleDeposit",
-            "type": "tuple"
-          },
-          {
-            "components": [
-              {
-                "internalType": "address",
-                "name": "token",
-                "type": "address"
-              },
-              {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-              }
-            ],
-            "internalType": "struct ERC3000Data.Collateral",
-            "name": "challengeDeposit",
-            "type": "tuple"
-          },
-          {
-            "components": [
-              {
-                "internalType": "address",
-                "name": "token",
-                "type": "address"
-              },
-              {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-              }
-            ],
-            "internalType": "struct ERC3000Data.Collateral",
-            "name": "vetoDeposit",
-            "type": "tuple"
-          },
-          {
-            "internalType": "address",
-            "name": "resolver",
-            "type": "address"
-          },
-          {
-            "internalType": "bytes",
-            "name": "rules",
-            "type": "bytes"
-          }
-        ],
-        "internalType": "struct ERC3000Data.Config",
-        "name": "_config",
-        "type": "tuple"
       },
       {
         "internalType": "bytes",


### PR DESCRIPTION
- Creates two Apollo graphQL clients, to dynamically switch between them depending on the selected chain. (This will be removed in the future as soon as we integrate with the server)
- Updates ABIs to reflect latest contract changes.
- Updates GraphQL query to use the latest schema.
