### PR TITLE
Fix GovernToken tests

### DIFF
--- a/packages/govern-token/contracts/factories/GovernTokenFactory.sol
+++ b/packages/govern-token/contracts/factories/GovernTokenFactory.sol
@@ -25,8 +25,8 @@ contract GovernTokenFactory {
 
     function newToken(
         address _initialMinter,
-        string memory _tokenName,
-        string memory _tokenSymbol,
+        string calldata _tokenName,
+        string calldata _tokenSymbol,
         uint8 _tokenDecimals,
         bool _useProxies
     ) external returns (


### PR DESCRIPTION
The Solidity compiler was complaining that `memory` was used instead of `calldata` in `GovernTokenFactory#newToken`.

This made the tests fail on master - and this PR should fix that.﻿
