### PR TITLE
Remove collateral from `Scheduled` event

### DIFF
--- a/packages/erc3k/contracts/IERC3000.sol
+++ b/packages/erc3k/contracts/IERC3000.sol
@@ -26,7 +26,7 @@ abstract contract IERC3000 is ERC3000Interface {
      * @return containerHash
      */
     function schedule(ERC3000Data.Container memory container) virtual public returns (bytes32 containerHash);
-    event Scheduled(bytes32 indexed containerHash, ERC3000Data.Payload payload, ERC3000Data.Collateral collateral);
+    event Scheduled(bytes32 indexed containerHash, ERC3000Data.Payload payload);
 
     /**
      * @notice Executes an action after its execution delay has passed and its state hasn't been altered by a challenge or veto

--- a/packages/govern-core/contracts/pipelines/GovernQueue.sol
+++ b/packages/govern-core/contracts/pipelines/GovernQueue.sol
@@ -114,7 +114,7 @@ contract GovernQueue is IERC3000, AdaptativeERC165, IArbitrable, ACL {
         // TODO: pay court tx fee
 
         // emit an event to ensure data availability of all state that cannot be otherwise fetched (see how config isn't emitted since an observer should already have it)
-        emit Scheduled(containerHash, _container.payload, collateral);
+        emit Scheduled(containerHash, _container.payload);
     }
 
     /**


### PR DESCRIPTION
I imagine this requires changes in ERC 3k itself as it breaks the interface proposed in that ERC? :thinking: 

Also, I tried looking for references to the collateral property from the `Scheduled` event in all of the other packages, and it doesn't seem like it was being used anywhere, but I'd love for someone else to double-check that for me.

Closes #93 