### PR TITLE
Govern: E2E tests

### DIFF
--- a/packages/govern-server/.gitignore
+++ b/packages/govern-server/.gitignore
@@ -1,0 +1,1 @@
+nohup.out

--- a/packages/govern/internal/actions/DaoAction.ts
+++ b/packages/govern/internal/actions/DaoAction.ts
@@ -4,7 +4,7 @@ import dao, { Dao } from '../clients/graphql/queries/dao'
 /**
  * @class DaoAction
  */
-export default class DaoAction extends AbstractAction<Dao> {
+export default class DaoAction extends AbstractAction {
   /**
    * Contains the GraphQL query of the current action
    *
@@ -21,5 +21,20 @@ export default class DaoAction extends AbstractAction<Dao> {
    */
   constructor(parameters: { name: string }) {
     super(parameters)
+  }
+
+  /**
+   * Will execute the action and returns the response as expected.
+   *
+   * @method execute
+   *
+   * @returns {Promise<Dao>}
+   *
+   * @public
+   */
+  public async execute(): Promise<Dao> {
+    const response = await super.execute()
+
+    return response.dao;
   }
 }

--- a/packages/govern/internal/actions/DaosAction.ts
+++ b/packages/govern/internal/actions/DaosAction.ts
@@ -4,7 +4,7 @@ import daos, { Daos } from '../clients/graphql/queries/daos'
 /**
  * @class DaosAction
  */
-export default class DaosAction extends AbstractAction<Daos> {
+export default class DaosAction extends AbstractAction {
   /**
    * Contains the GraphQL query of the current action
    *
@@ -13,4 +13,19 @@ export default class DaosAction extends AbstractAction<Daos> {
    * @protected
    */
   protected gqlQuery: string = daos
+
+  /**
+   * Will execute the action and returns the response as expected.
+   *
+   * @method execute
+   *
+   * @returns {Promise<Daos>}
+   *
+   * @public
+   */
+  public async execute(): Promise<Daos> {
+    const response = await super.execute()
+
+    return response.daos;
+  }
 }

--- a/packages/govern/internal/actions/lib/AbstractAction.ts
+++ b/packages/govern/internal/actions/lib/AbstractAction.ts
@@ -3,7 +3,7 @@ import Configuration from '../../configuration/Configuration'
 /**
  * @abstract AbstractAction
  */
-export default abstract class AbstractAction<T> {
+export default abstract class AbstractAction {
   /**
    * Contains the GraphQL query of the current action
    *
@@ -65,7 +65,7 @@ export default abstract class AbstractAction<T> {
    *
    * @public
    */
-  public execute(): Promise<T> {
+  public execute(): Promise<any> {
     return this.configuration.client.request(this.gqlQuery, this.parameters)
   }
 }

--- a/packages/govern/internal/clients/graphql/fragments/registry-entry.ts
+++ b/packages/govern/internal/clients/graphql/fragments/registry-entry.ts
@@ -78,7 +78,7 @@ export interface RegistryEntry {
       executionDelay: string
       scheduleDeposit: Collateral,
       challengeDeposit: Collateral,
-      resovler: string,
+      resolver: string,
       rules: string
     },
     queued: {

--- a/packages/govern/internal/clients/graphql/queries/dao.ts
+++ b/packages/govern/internal/clients/graphql/queries/dao.ts
@@ -3,6 +3,7 @@ import registryEntry, { RegistryEntry } from '../fragments/registry-entry'
 export interface Dao {
   id: string,
   metadata: string,
+  address: string,
   registryEntries: RegistryEntry[]
 }
 

--- a/packages/govern/internal/clients/graphql/queries/dao.ts
+++ b/packages/govern/internal/clients/graphql/queries/dao.ts
@@ -8,7 +8,7 @@ export interface Dao {
 }
 
 const dao: string = `
-    query DAO($name: String) {
+    query DAO($name: String!) {
       dao(name: $name) {
         id
         address

--- a/packages/govern/internal/clients/graphql/queries/daos.ts
+++ b/packages/govern/internal/clients/graphql/queries/daos.ts
@@ -1,9 +1,7 @@
 import { Dao } from './dao'
 import registryEntry from '../fragments/registry-entry'
 
-export interface Daos {
-  daos: Dao[]
-}
+export type Daos = Dao[]
 
 const daos: string = `
    query DAOS {

--- a/packages/govern/jest.config.e2e.js
+++ b/packages/govern/jest.config.e2e.js
@@ -1,0 +1,4 @@
+const jestConfig = require('./jest.config.js')
+jestConfig.testMatch = ['/**/**Test.e2e.ts']
+
+module.exports = jestConfig;

--- a/packages/govern/package.json
+++ b/packages/govern/package.json
@@ -15,7 +15,7 @@
     "build:cjs": "tsc -p ./tsconfig.cjs.json",
     "dev:esm": "yarn build:esm --watch",
     "dev:cjs": "yarn build:cjs --watch",
-    "test": "jest",
+    "test": "jest && yarn e2e",
     "e2e": "./scripts/start.e2e.sh",
     "prepublishOnly": "yarn build"
   },

--- a/packages/govern/package.json
+++ b/packages/govern/package.json
@@ -16,6 +16,7 @@
     "dev:esm": "yarn build:esm --watch",
     "dev:cjs": "yarn build:cjs --watch",
     "test": "jest",
+    "e2e": "./scripts/start.e2e.sh",
     "prepublishOnly": "yarn build"
   },
   "files": [

--- a/packages/govern/scripts/start.e2e.sh
+++ b/packages/govern/scripts/start.e2e.sh
@@ -2,7 +2,7 @@
 
 # Go to govern server package and start dev server
 cd ../govern-server/
-yarn dev
+nohup yarn dev >>/dev/null 2>>/dev/null &
 
 # Go to govern package and start e2e tests
 cd ../govern

--- a/packages/govern/scripts/start.e2e.sh
+++ b/packages/govern/scripts/start.e2e.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Go to govern server package and start dev server
+cd ../govern-server/
+yarn dev
+
+# Go to govern package and start e2e tests
+cd ../govern
+jest -c ./jest.config.e2e.js

--- a/packages/govern/scripts/start.e2e.sh
+++ b/packages/govern/scripts/start.e2e.sh
@@ -6,4 +6,5 @@ yarn dev
 
 # Go to govern package and start e2e tests
 cd ../govern
+yarn build
 jest -c ./jest.config.e2e.js

--- a/packages/govern/tests/e2e/daoTest.e2e.ts
+++ b/packages/govern/tests/e2e/daoTest.e2e.ts
@@ -9,8 +9,8 @@ describe('[e2e] dao Test', () => {
   })
 
   it('calls dao and returns as expected', async () => {
-    const response = await dao("")
+    const response = await dao("M")
 
-    expect(response.dao.address).toEqual('0x24319b199e9e3867ede90eaf0fad56168c54d077')
+    expect(response.address).toEqual('0x24319b199e9e3867ede90eaf0fad56168c54d077')
   })
 })

--- a/packages/govern/tests/e2e/daoTest.e2e.ts
+++ b/packages/govern/tests/e2e/daoTest.e2e.ts
@@ -1,4 +1,4 @@
-import { configure, dao } from '../../public'
+import { configure, dao } from '@aragon/govern'
 
 /**
  * dao e2e test

--- a/packages/govern/tests/e2e/daoTest.e2e.ts
+++ b/packages/govern/tests/e2e/daoTest.e2e.ts
@@ -1,0 +1,16 @@
+import { configure, dao } from '../../public'
+
+/**
+ * dao e2e test
+ */
+describe('[e2e] dao Test', () => {
+  beforeEach(() => {
+    configure({ governURL: 'http://localhost:3000/' })
+  })
+
+  it('calls dao and returns as expected', async () => {
+    const response = await dao("")
+
+    expect(response.dao.address).toEqual('0x24319b199e9e3867ede90eaf0fad56168c54d077')
+  })
+})

--- a/packages/govern/tests/e2e/daoTest.e2e.ts
+++ b/packages/govern/tests/e2e/daoTest.e2e.ts
@@ -11,6 +11,30 @@ describe('[e2e] dao Test', () => {
   it('calls dao and returns as expected', async () => {
     const response = await dao("M")
 
+    expect(response.id).toEqual('0x24319b199e9e3867ede90eaf0fad56168c54d077')
+
     expect(response.address).toEqual('0x24319b199e9e3867ede90eaf0fad56168c54d077')
+
+    expect(response.metadata).toBeDefined()
+
+    expect(response.registryEntries[0].id).toEqual('M')
+
+    expect(response.registryEntries[0].name).toEqual('M')
+
+    expect(response.registryEntries[0].queue.id).toEqual('0x498cbf401df68196dc41b4bf53817088cb70b815')
+
+    expect(response.registryEntries[0].queue.address).toEqual('0x498cbf401df68196dc41b4bf53817088cb70b815')
+
+    expect(response.registryEntries[0].queue.config.executionDelay).toBeDefined()
+
+    expect(response.registryEntries[0].queue.config.scheduleDeposit).toBeDefined()
+
+    expect(response.registryEntries[0].queue.config.challengeDeposit).toBeDefined()
+
+    expect(response.registryEntries[0].queue.config.resolver).toBeDefined()
+
+    expect(response.registryEntries[0].queue.config.rules).toBeDefined()
+
+    expect(Array.isArray(response.registryEntries[0].queue.queued)).toEqual(true)
   })
 })

--- a/packages/govern/tests/e2e/daosTest.e2e.ts
+++ b/packages/govern/tests/e2e/daosTest.e2e.ts
@@ -11,6 +11,30 @@ describe('[e2e] daos Test', () => {
   it('calls daos and returns as expected', async () => {
     const response = await daos()
 
+    expect(response[0].id).toEqual('0x24319b199e9e3867ede90eaf0fad56168c54d077')
+
     expect(response[0].address).toEqual('0x24319b199e9e3867ede90eaf0fad56168c54d077')
+
+    expect(response[0].metadata).toBeDefined()
+
+    expect(response[0].registryEntries[0].id).toEqual('M')
+
+    expect(response[0].registryEntries[0].name).toEqual('M')
+
+    expect(response[0].registryEntries[0].queue.id).toEqual('0x498cbf401df68196dc41b4bf53817088cb70b815')
+
+    expect(response[0].registryEntries[0].queue.address).toEqual('0x498cbf401df68196dc41b4bf53817088cb70b815')
+
+    expect(response[0].registryEntries[0].queue.config.executionDelay).toBeDefined()
+
+    expect(response[0].registryEntries[0].queue.config.scheduleDeposit).toBeDefined()
+
+    expect(response[0].registryEntries[0].queue.config.challengeDeposit).toBeDefined()
+
+    expect(response[0].registryEntries[0].queue.config.resolver).toBeDefined()
+
+    expect(response[0].registryEntries[0].queue.config.rules).toBeDefined()
+
+    expect(Array.isArray(response[0].registryEntries[0].queue.queued)).toEqual(true)
   })
 })

--- a/packages/govern/tests/e2e/daosTest.e2e.ts
+++ b/packages/govern/tests/e2e/daosTest.e2e.ts
@@ -11,6 +11,6 @@ describe('[e2e] daos Test', () => {
   it('calls daos and returns as expected', async () => {
     const response = await daos()
 
-    expect(response.daos[0].address).toEqual('0x24319b199e9e3867ede90eaf0fad56168c54d077')
+    expect(response[0].address).toEqual('0x24319b199e9e3867ede90eaf0fad56168c54d077')
   })
 })

--- a/packages/govern/tests/e2e/daosTest.e2e.ts
+++ b/packages/govern/tests/e2e/daosTest.e2e.ts
@@ -1,4 +1,4 @@
-import { configure, daos } from '../../public'
+import { configure, daos } from '@aragon/govern'
 
 /**
  * daos e2e test

--- a/packages/govern/tests/e2e/daosTest.e2e.ts
+++ b/packages/govern/tests/e2e/daosTest.e2e.ts
@@ -1,0 +1,16 @@
+import { configure, daos } from '../../public'
+
+/**
+ * daos e2e test
+ */
+describe('[e2e] daos Test', () => {
+  beforeEach(() => {
+    configure({ governURL: 'http://localhost:3000/' })
+  })
+
+  it('calls daos and returns as expected', async () => {
+    const response = await daos()
+
+    expect(response.daos[0].address).toEqual('0x24319b199e9e3867ede90eaf0fad56168c54d077')
+  })
+})

--- a/packages/govern/tests/e2e/queryTest.e2e.ts
+++ b/packages/govern/tests/e2e/queryTest.e2e.ts
@@ -1,4 +1,4 @@
-import { configure, query } from '../../public'
+import { configure, query } from '@aragon/govern'
 
 /**
  * query e2e test

--- a/packages/govern/tests/e2e/queryTest.e2e.ts
+++ b/packages/govern/tests/e2e/queryTest.e2e.ts
@@ -1,0 +1,24 @@
+import { configure, query } from '../../public'
+
+/**
+ * query e2e test
+ */
+describe('[e2e] query Test', () => {
+  beforeEach(() => {
+    configure({ governURL: 'http://localhost:3000/' })
+  })
+
+  it('calls query and returns as expected', async () => {
+    const response = await query(`
+      query DAOS {
+        daos {
+          id
+          address
+          metadata
+        }
+      }
+    `)
+
+    expect(response.daos[0].address).toEqual('0x24319b199e9e3867ede90eaf0fad56168c54d077')
+  })
+})

--- a/packages/govern/tests/internal/actions/DaoActionTest.ts
+++ b/packages/govern/tests/internal/actions/DaoActionTest.ts
@@ -1,10 +1,35 @@
+import GraphQLClient from '../../../internal/clients/graphql/GraphQLClient'
 import DaoAction from '../../../internal/actions/DaoAction'
+import dao from '../../../internal/clients/graphql/queries/dao'
+
+//Mocks
+jest.mock('../../../internal/clients/graphql/GraphQLClient')
 
 /**
  * DaoAction test
  */
 describe('DaoActionTest', () => {
-  it('calls the constructor and initiates the class as expected', () => {
-    new DaoAction({ name: 'myName' })
+  let action: DaoAction,
+    clientMockClass = GraphQLClient as jest.MockedClass<typeof GraphQLClient>,
+    clientMock: GraphQLClient
+
+
+  beforeEach(() => {
+    action = new DaoAction({ name: 'myName' })
+    clientMock = clientMockClass.mock.instances[0]
+  })
+
+  it('calls execute and does map the response accordingly', async () => {
+    clientMock.request = jest.fn((query: string, args: any = {}) => {
+      expect(query).toEqual(dao);
+
+      expect(args).toEqual({name: 'myName'})
+
+      return Promise.resolve({dao: true})
+    });
+
+    const response = await action.execute();
+
+    expect(response).toEqual(true)
   })
 })

--- a/packages/govern/tests/internal/actions/DaosActionTest.ts
+++ b/packages/govern/tests/internal/actions/DaosActionTest.ts
@@ -1,10 +1,35 @@
+import GraphQLClient from '../../../internal/clients/graphql/GraphQLClient'
 import DaosAction from '../../../internal/actions/DaosAction'
+import daos from '../../../internal/clients/graphql/queries/daos'
+
+//Mocks
+jest.mock('../../../internal/clients/graphql/GraphQLClient')
 
 /**
  * DaosAction test
  */
-describe('DaosActionTest', () => {
-  it('calls the constructor and initiates the class as expected', () => {
-    new DaosAction()
+describe('DaoActionTest', () => {
+  let action: DaosAction,
+    clientMockClass = GraphQLClient as jest.MockedClass<typeof GraphQLClient>,
+    clientMock: GraphQLClient
+
+
+  beforeEach(() => {
+    action = new DaosAction()
+    clientMock = clientMockClass.mock.instances[0]
+  })
+
+  it('calls execute and does map the response accordingly', async () => {
+    clientMock.request = jest.fn((query: string, args: any = {}) => {
+      expect(query).toEqual(daos);
+
+      expect(args).toEqual({})
+
+      return Promise.resolve({daos: true})
+    });
+
+    const response = await action.execute();
+
+    expect(response).toEqual(true)
   })
 })

--- a/packages/govern/tests/internal/actions/lib/AbstractActionTest.ts
+++ b/packages/govern/tests/internal/actions/lib/AbstractActionTest.ts
@@ -1,11 +1,7 @@
 import AbstractAction from '../../../../internal/actions/lib/AbstractAction'
 import GraphQLClient from '../../../../internal/clients/graphql/GraphQLClient'
-import gql from 'graphql-tag'
 
-// Created to be able to test the abstract class AbstractAction
-interface Test { }
-
-class TestAction extends AbstractAction<Test> {
+class TestAction extends AbstractAction {
   protected gqlQuery: string = 'query Test { name }'
 }
 
@@ -15,7 +11,7 @@ jest.mock('../../../../internal/clients/graphql/GraphQLClient')
  * AbstractAction test
  */
 describe('AbstractActionTest', () => {
-  let abstractAction: AbstractAction<Test>,
+  let abstractAction: AbstractAction,
     clientMock = GraphQLClient as jest.MockedClass<typeof GraphQLClient>,
     clientInstance: GraphQLClient
 


### PR DESCRIPTION
- basic setup e2e tests govern.js
- e2e tests for existing public actions
- TS types updated
- Query for ``dao(...)`` updated
- response data handling improved
- unit tests updated