### PR TITLE
CI/CD: Server and subgraph rinkeby on master commits, mainnet on v* tag

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# from .gitignore
+node_modules/
+yarn-error.log
+.env
+/packages/govern-server/dev-data/
+
+# extra ignores to help docker caching
+.git
+.github
+docker-compose.yml
+*.md

--- a/.github/workflows/server-ci-cd.yml
+++ b/.github/workflows/server-ci-cd.yml
@@ -12,7 +12,6 @@ env:
 
 jobs:
   build:
-    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/server-ci-cd.yml
+++ b/.github/workflows/server-ci-cd.yml
@@ -1,19 +1,23 @@
 name: Server CI/CD
 on:
   push:
+    branches:
+    - master
     tags:
     - v*
 env:
-  # This is a base repository and we use ${GITHUB_REF##*/} to set the version of the container
+  # This is a base repository and we use git refs to set the version of the container
+  # ${GITHUB_REF##*/} will be either a branch name or a tag depending on the event
   REPO: aragon/govern-server
 
 jobs:
   build:
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - run: docker login -u ${{secrets.DOCKERHUB_USER}} -p ${{secrets.DOCKERHUB_TOKEN}}
-    - run: .github/scripts/docker-build.sh packages/govern-server/ $REPO ${GITHUB_SHA}
+    - run: .github/scripts/docker-build.sh . $REPO ${GITHUB_SHA}
 
   release:
     runs-on: ubuntu-latest
@@ -24,7 +28,20 @@ jobs:
     - run: .github/scripts/docker-release.sh $REPO:${GITHUB_SHA} $REPO:${GITHUB_REF##*/}
     - run: .github/scripts/docker-release.sh $REPO:${GITHUB_SHA} $REPO:latest
 
-  deploy:
+  deploy-rinkeby:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+    - uses: actions/checkout@v2
+    - run: .github/scripts/kubectl-config.sh ${{secrets.KUBE_CA}} ${{secrets.KUBE_SERVER}} ${{secrets.KUBE_TOKEN}}
+    - run: .github/scripts/kubectl-set-image.sh govern-server-rinkeby $REPO:${GITHUB_REF##*/}
+    - run: .github/scripts/kubectl-wait-ready.sh govern-server-rinkeby
+    # wait 10 sec for k8s to reroute ingress and check the endpoint
+    - run: sleep 10 && curl --fail https://govern-rinkeby.backend.aragon.org -H accept:text/html
+
+  deploy-mainnet:
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     needs: release
     steps:

--- a/.github/workflows/subgraph-ci-cd.yml
+++ b/.github/workflows/subgraph-ci-cd.yml
@@ -1,6 +1,8 @@
 name: Subgraph CI/CD
 on:
   push:
+    branches:
+    - master
     tags:
     - v*
 env:
@@ -11,7 +13,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: yarn
-    - run: .github/scripts/kubectl-config.sh ${{secrets.KUBE_CA}} ${{secrets.KUBE_SERVER}} ${{secrets.KUBE_TOKEN}}
-    - run: yarn deploy:subgraph:rinkeby
-    - run: yarn deploy:subgraph:mainnet
+
+    - name: Install node
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12
+
+    - name: Cache yarn modules
+      uses: actions/cache@v2
+      with:
+        path: '**/node_modules'
+        key: yarn-${{ hashFiles('yarn.lock') }}
+
+    - name: Install dependencies
+      run: yarn install --frozen-lockfile
+
+    - name: Configure k8s
+      run: .github/scripts/kubectl-config.sh ${{secrets.KUBE_CA}} ${{secrets.KUBE_SERVER}} ${{secrets.KUBE_TOKEN}}
+
+    - name: Deploy rinkeby
+      if: github.ref == 'refs/heads/master'
+      run: yarn deploy:subgraph:rinkeby
+
+    - name: Deploy mainnet
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: yarn deploy:subgraph:mainnet

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:12.19.0-alpine
+RUN apk add --no-cache git bash curl
+
+WORKDIR /app
+
+# copy all package json files
+COPY ./package.json                                   /app/package.json
+COPY ./packages/erc3k/package.json                    /app/packages/erc3k/package.json
+COPY ./packages/erc3kjs/package.json                  /app/packages/erc3kjs/package.json
+COPY ./packages/govern/package.json                   /app/packages/govern/package.json
+COPY ./packages/govern-console/package.json           /app/packages/govern-console/package.json
+COPY ./packages/govern-contract-utils/package.json    /app/packages/govern-contract-utils/package.json
+COPY ./packages/govern-core/package.json              /app/packages/govern-core/package.json
+COPY ./packages/govern-create/package.json            /app/packages/govern-create/package.json
+COPY ./packages/govern-discord/package.json           /app/packages/govern-discord/package.json
+COPY ./packages/govern-server/package.json            /app/packages/govern-server/package.json
+COPY ./packages/govern-subgraph/package.json          /app/packages/govern-subgraph/package.json
+COPY ./packages/govern-token/package.json             /app/packages/govern-token/package.json
+
+# install dependencies
+COPY ./yarn.lock                                      /app/yarn.lock
+RUN yarn install --frozen-lockfile
+
+# try building the app
+COPY . .
+RUN yarn build:contracts
+
+CMD echo specify one of the package.json scripts in command line

--- a/packages/govern-server/Dockerfile
+++ b/packages/govern-server/Dockerfile
@@ -1,9 +1,0 @@
-FROM node:12.19.0-alpine
-
-WORKDIR /app
-
-COPY ./package.json /app/package.json
-RUN yarn install
-
-COPY . .
-CMD yarn start:server


### PR DESCRIPTION
With these manifests rinkeby subgraph/server will deploy on every master commit and mainnet on v* tag.
Also I moved server `Dockerfile` to the top so we install it using `yarn.lock` file.

closes #174 