### PR TITLE
Subgraph: fix paths + add a build script

### DIFF
--- a/packages/govern-subgraph/README.md
+++ b/packages/govern-subgraph/README.md
@@ -7,9 +7,25 @@
 Ensure the monorepo’s dependencies are installed:
 
 ```console
-cd ../.. && yarn
-cd packages/govern-subgraph
+cd ../.. && yarn && cd packages/govern-subgraph
 ```
+
+## Build & deploy the subgraph
+
+You can build and deploy the subgraph using a single `yarn deploy-<network>` command:
+
+```console
+GRAPH_KEY=<GRAPH_KEY> yarn deploy-<DESIRED_NETWORK> <THEGRAPH_USERNAME> <SUBGRAPH_NAME> <DESIRED_NETWORK>
+```
+
+Replace the placeholders by the following:
+
+- `<GRAPH_KEY>`: The Graph key (this is only needed when deploying on The Graph).
+- `<THEGRAPH_USERNAME>`: username of your subgraph (usually your GitHub username).
+- `<SUBGRAPH_NAME>`: name of the subgraph.
+- `<DESIRED_NETWORK>`: one of the available networks (see package.json).
+
+## Build only
 
 Generate the `subgraph.yaml` file corresponding to your network:
 
@@ -19,30 +35,13 @@ yarn manifest-<DESIRED_NETWORK>
 
 Replacing `<DESIRED_NETWORK>` by one of the available networks (see package.json).
 
-Generate the types from the ABIs and the GraphQL schema:
-
-```console
-yarn codegen
-```
-
-The generated code is used by the subgraph mapping scripts. Compile the subgraph:
+You can now run the `build` command, which will generate the types and compile the subgraph:
 
 ```console
 yarn build
 ```
 
-You are now ready to deploy the subgraph. This is the command to use:
-
-```console
-GRAPH_KEY=<GRAPH_KEY> yarn deploy-<DESIRED_NETWORK> <THEGRAPH_USERNAME> <SUBGRAPH_NAME> <DESIRED_NETWORK>
-```
-
-Replacing:
-
-- `<GRAPH_KEY>` by your The Graph key (this is only needed when deploying on The Graph).
-- `<THEGRAPH_USERNAME>` by the username used for your subgraph (usually your GitHub username).
-- `<SUBGRAPH_NAME>` by the name of the subgraph itself.
-- `<DESIRED_NETWORK>` by one of the available networks (see package.json).
+You are now ready to deploy the subgraph using [the `graph deploy` command](https://thegraph.com/docs/deploy-a-subgraph).
 
 ### Deploy the subgraph locally
 
@@ -110,6 +109,7 @@ Tracked:
 - `Revoked`
 
 Left out:
+
 - `ETHDeposited`
 
 #### GovernQueue.sol
@@ -138,4 +138,3 @@ Tracked:
 - `SetMetadata`
 
 Left out: None.
-

--- a/packages/govern-subgraph/manifest/templates/contracts/GovernRegistry.template.yaml
+++ b/packages/govern-subgraph/manifest/templates/contracts/GovernRegistry.template.yaml
@@ -15,7 +15,7 @@
       - Govern
     abis:
       - name: GovernRegistry
-        file: ./node_modules/@aragon/govern-core/abi/GovernRegistry.json
+        file: $GOVERN_CORE_MODULE/abi/GovernRegistry.json
     eventHandlers:
       - event: Registered(indexed address,address,indexed address,indexed address,string)
         handler: handleRegistered

--- a/packages/govern-subgraph/package.json
+++ b/packages/govern-subgraph/package.json
@@ -2,8 +2,7 @@
   "name": "@aragon/govern-subgraph",
   "version": "1.0.1-beta.0",
   "scripts": {
-    "codegen": "rm -rf generated; graph codegen",
-    "build": "rm -rf build; graph build",
+    "build": "scripts/build-subgraph.sh",
     "manifest-mainnet": "scripts/build-manifest.sh mainnet",
     "manifest-mainnet-staging": "STAGING=true scripts/build-manifest.sh mainnet",
     "manifest-rinkeby": "scripts/build-manifest.sh rinkeby",

--- a/packages/govern-subgraph/scripts/build-manifest.sh
+++ b/packages/govern-subgraph/scripts/build-manifest.sh
@@ -11,6 +11,8 @@ fi
 
 DATA=manifest/data/$FILE
 
+GOVERN_CORE_MODULE=$(node -e 'console.log(require("path").dirname(require.resolve("@aragon/govern-core/package.json")))')
+
 echo 'Generating manifest from data file: '$DATA
 cat $DATA
 
@@ -18,4 +20,6 @@ mustache \
   -p manifest/templates/sources/GovernRegistry.yaml \
   -p manifest/templates/contracts/GovernRegistry.template.yaml \
   $DATA \
-  subgraph.template.yaml > subgraph.yaml
+  subgraph.template.yaml \
+  | sed -e "s#\$GOVERN_CORE_MODULE#$GOVERN_CORE_MODULE#g" \
+  > subgraph.yaml

--- a/packages/govern-subgraph/scripts/build-subgraph.sh
+++ b/packages/govern-subgraph/scripts/build-subgraph.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -eu
+
+if [ ! -f "./subgraph.yaml" ]; then
+  echo "The file subgraph.yaml doesn’t exist. Did you run yarn manifest-<network>?"
+  exit 1
+fi
+
+rm -rf generated
+rm -rf build
+
+graph codegen
+graph build

--- a/packages/govern-subgraph/subgraph.template.yaml
+++ b/packages/govern-subgraph/subgraph.template.yaml
@@ -26,7 +26,7 @@ templates:
         - Role
       abis:
         - name: GovernQueue
-          file: ./node_modules/@aragon/govern-core/abi/GovernQueue.json
+          file: $GOVERN_CORE_MODULE/abi/GovernQueue.json
       eventHandlers:
         - event: Configured(indexed bytes32,indexed address,(uint256,(address,uint256),(address,uint256),address,bytes))
           handler: handleConfigured
@@ -66,7 +66,7 @@ templates:
         - Role
       abis:
         - name: Govern
-          file: ./node_modules/@aragon/govern-core/abi/Govern.json
+          file: $GOVERN_CORE_MODULE/abi/Govern.json
       eventHandlers:
         - event: Executed(indexed address,(address,uint256,bytes)[],bytes32,bytes32,bytes[])
           handler: handleExecuted


### PR DESCRIPTION
The build script runs `graph codegen` and `graph build` at once. It also displays an error message if the manifest files and `subgraph.yaml` don’t exist, explaining how to generate them.

The package paths in the templates are now resolved using the Node algorithm.