### PR TITLE
Console: base routing on network / chain ID rather than DAO address

### DIFF
--- a/packages/govern-console/src/App.tsx
+++ b/packages/govern-console/src/App.tsx
@@ -1,13 +1,15 @@
 import React, { useEffect } from 'react'
-import { Route, Switch, useLocation } from 'react-router-dom'
+import { Redirect, Route, Switch, useLocation } from 'react-router-dom'
 import 'styled-components/macro'
-import TopHeader from './components/Header/Header'
 import SelectDao from './pages/SelectDao'
 import ViewDao from './pages/ViewDao'
-import ErcTool from './apps/Erc'
+import TopHeader from './components/Header/Header'
+import { useChainId } from './Providers/ChainId'
+import { getNetworkName } from './lib/web3-utils'
 
 function App() {
   const location: any = useLocation()
+  const { chainId } = useChainId()
 
   useEffect(() => {
     window.scrollTo(0, 0)
@@ -24,12 +26,12 @@ function App() {
       <TopHeader />
       <Switch>
         <Route exact path="/">
+          <Redirect to={`/${getNetworkName(chainId)}`} />
+        </Route>
+        <Route exact path="/:network">
           <SelectDao />
         </Route>
-        <Route exact path="/tools/erc">
-          <ErcTool />
-        </Route>
-        <Route path="/:daoAddress">
+        <Route path="/:network/:daoAddress">
           <ViewDao />
         </Route>
       </Switch>

--- a/packages/govern-console/src/components/Header/Header.tsx
+++ b/packages/govern-console/src/components/Header/Header.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect } from 'react'
+import { useHistory } from 'react-router-dom'
 import { ChainUnsupportedError } from 'use-wallet'
 import 'styled-components/macro'
 import Button from '../Button'
@@ -10,14 +11,7 @@ import AragonSvg from '../../assets/aragon-metal.svg'
 function Header() {
   const { chainId, setChainId } = useChainId()
   const { wallet } = useWallet()
-
-  const handleWalletConnection = useCallback(() => {
-    wallet.status === 'connected' ? wallet.reset() : wallet.connect('injected')
-  }, [wallet])
-
-  const handleChangeChain = useCallback(e => setChainId(e.target.value), [
-    setChainId,
-  ])
+  const history = useHistory()
 
   useEffect(() => {
     if (wallet!.error && wallet!.error instanceof ChainUnsupportedError) {
@@ -29,12 +23,27 @@ function Header() {
     }
   }, [chainId, wallet])
 
+  const handleChangeChain = useCallback(
+    e => {
+      setChainId(e.target.value)
+      // When we change the chain ID, the DAO might not exist,
+      // so we must revert back to the DAO selection screen.
+      history.push(`/${getNetworkName(e.target.value)}`)
+    },
+    [history, setChainId],
+  )
+
+  const handleGoToHome = useCallback(() => history.push('/'), [history])
+
+  const handleWalletConnection = useCallback(() => {
+    wallet.status === 'connected' ? wallet.reset() : wallet.connect('injected')
+  }, [wallet])
+
   return (
     <header
       css={`
         display: flex;
         justify-content: space-between;
-
         width: 100%;
         border: 2px solid rgba(255, 255, 255, 0.2);
         padding: 8px;
@@ -47,7 +56,23 @@ function Header() {
           align-items: center;
         `}
       >
-        <img src={AragonSvg} width="36" alt="Grey Eagle Aragon logo" />
+        <button
+          type="button"
+          onClick={handleGoToHome}
+          css={`
+            background: transparent;
+            border: 0px;
+            &:hover {
+              cursor: pointer;
+            }
+            &:active {
+              position: relative;
+              top: 1px;
+            }
+          `}
+        >
+          <img src={AragonSvg} width="36" alt="Grey Eagle Aragon logo" />
+        </button>
         <h1
           css={`
             flex-grow: 1;
@@ -86,7 +111,6 @@ function Header() {
             background: transparent;
             color: white;
             cursor: pointer;
-
             &:hover {
               background: rgba(255, 255, 255, 0.2);
             }

--- a/packages/govern-console/src/components/Header/Header.tsx
+++ b/packages/govern-console/src/components/Header/Header.tsx
@@ -60,6 +60,7 @@ function Header() {
           type="button"
           onClick={handleGoToHome}
           css={`
+            display: flex;
             background: transparent;
             border: 0px;
             &:hover {
@@ -71,17 +72,17 @@ function Header() {
             }
           `}
         >
-          <img src={AragonSvg} width="36" alt="Grey Eagle Aragon logo" />
+          <img src={AragonSvg} width="36" alt="" />
+          <h1
+            css={`
+              flex-grow: 1;
+              font-size: 24px;
+              margin-left: 8px;
+            `}
+          >
+            Govern Console
+          </h1>
         </button>
-        <h1
-          css={`
-            flex-grow: 1;
-            font-size: 24px;
-            margin-left: 8px;
-          `}
-        >
-          Govern Console
-        </h1>
       </div>
       <div>
         <label

--- a/packages/govern-console/src/index.tsx
+++ b/packages/govern-console/src/index.tsx
@@ -13,11 +13,9 @@ const GlobalStyle = createGlobalStyle`
   *, *:before, *:after {
     box-sizing: border-box;
   }
-
   html {
     -webkit-overflow-scrolling: touch;
   }
-
   body {
     height: 0;
     min-height: 100vh;
@@ -25,23 +23,19 @@ const GlobalStyle = createGlobalStyle`
     color: white;
     font-family: 'Roboto Mono', Helvetica, sans-serif;
   }
-
   body, ul, p, h1, h2, h3, h4, h5, h6 {
     margin: 0;
     padding: 0;
   }
-
   button, select, input, textarea, h1, h2, h3, h4, h5, h6 {
     font-size: inherit;
     font-family: inherit;
     font-weight: inherit;
     line-height: inherit;
   }
-
   a, button, select, input, textarea {
     color: inherit;
   }
-
   strong, b {
     font-weight: 600;
   }
@@ -49,14 +43,14 @@ const GlobalStyle = createGlobalStyle`
 
 render(
   <ReactQueryCacheProvider queryCache={queryCache}>
-    <GeneralProvider>
-      <React.StrictMode>
-        <GlobalStyle />
-        <HashRouter>
+    <HashRouter>
+      <GeneralProvider>
+        <React.StrictMode>
+          <GlobalStyle />
           <App />
-        </HashRouter>
-      </React.StrictMode>
-    </GeneralProvider>
+        </React.StrictMode>
+      </GeneralProvider>
+    </HashRouter>
   </ReactQueryCacheProvider>,
   document.getElementById('root'),
 )

--- a/packages/govern-console/src/lib/web3-utils.js
+++ b/packages/govern-console/src/lib/web3-utils.js
@@ -28,8 +28,8 @@ export function addressesEqual(first, second) {
 export function getNetworkName(chainId) {
   chainId = String(chainId)
 
-  if (chainId === '1') return 'Mainnet'
-  if (chainId === '4') return 'Rinkeby'
+  if (chainId === '1') return 'mainnet'
+  if (chainId === '4') return 'rinkeby'
   if (chainId === '100') return 'xDai'
 
   return 'Unknown'
@@ -71,8 +71,8 @@ export const addressPattern = '(0x)?[0-9a-fA-F]{40}'
  * characters on both sides of the ellipsis.
  *
  * Examples:
- *   shortenAddress('0x19731977931271')    // 0x1973‚Ä¶1271
- *   shortenAddress('0x19731977931271', 2) // 0x19‚Ä¶71
+ *   shortenAddress('0x19731977931271')    // 0x1973…1271
+ *   shortenAddress('0x19731977931271', 2) // 0x19…71
  *   shortenAddress('0x197319')            // 0x197319 (already short enough)
  *
  * @param {string} address The address to shorten

--- a/packages/govern-console/src/pages/SelectDao.tsx
+++ b/packages/govern-console/src/pages/SelectDao.tsx
@@ -1,25 +1,18 @@
 import React, { useCallback, useState } from 'react'
-import { useHistory } from 'react-router-dom'
+import { useHistory, useParams } from 'react-router-dom'
 import 'styled-components/macro'
 import Button from '../components/Button'
 
-const KNOWN_TOOLS = [
-  {
-    name: 'ERC-20 Tool',
-    id: 'erc',
-  },
-]
-
-export default function DaoSelector() {
+export default function SelectDao() {
   const [daoName, setDaoName] = useState('')
   const history = useHistory()
-
+  const { network }: any = useParams()
   const handleChangeDaoAddress = useCallback(e => {
     setDaoName(e.target.value)
   }, [])
   const handleGoToDao = useCallback(() => {
-    history.push(`/${daoName}`)
-  }, [daoName, history])
+    history.push(`/${network}/${daoName}`)
+  }, [daoName, history, network])
 
   return (
     <>
@@ -52,62 +45,6 @@ export default function DaoSelector() {
           Go to DAO
         </Button>
       </form>
-      <div
-        css={`
-          padding: 8px;
-          margin-top: ${4 * 8}px;
-          border: 2px solid rgba(255, 255, 255, 0.2);
-        `}
-      >
-        <h2>Tools</h2>
-        {KNOWN_TOOLS.map(({ name, id }) => (
-          <ToolCard key={id} name={name} id={id} />
-        ))}
-      </div>
     </>
-  )
-}
-
-type ToolCardProps = {
-  name: string
-  id: string
-}
-
-function ToolCard({ name, id }: ToolCardProps) {
-  const history = useHistory()
-
-  const handleCardClick = useCallback(() => {
-    history.push(`/tools/${id}`)
-  }, [history, id])
-
-  return (
-    <button
-      type="button"
-      onClick={handleCardClick}
-      css={`
-        position: relative;
-        background: transparent;
-        width: 280px;
-        height: 320px;
-        border: 2px solid transparent;
-        border-image: linear-gradient(
-          to bottom right,
-          #ad41bb 20%,
-          #ff7d7d 100%
-        );
-        border-image-slice: 1;
-        padding: 16px;
-        cursor: pointer;
-        &:not(:last-child) {
-          margin-right: 24px;
-          margin-bottom: 24px;
-        }
-        &:active {
-          top: 1px;
-        }
-      `}
-    >
-      {name}
-    </button>
   )
 }

--- a/packages/govern-console/src/pages/ViewDao.tsx
+++ b/packages/govern-console/src/pages/ViewDao.tsx
@@ -87,14 +87,23 @@ export default function DaoView() {
   const { chainId } = useChainId()
   const { daoAddress }: any = useParams()
   const { path } = useRouteMatch()
-  const { data, isLoading: loading, error } = useQuery('DAO_DATA', async () =>
-    request(
-      chainId === 4 ? env('RINKEBY_SUBGRAPH_URL') : env('MAINNET_SUBGRAPH_URL'),
-      DAO_QUERY,
-      {
-        name: daoAddress,
-      },
-    ),
+  const { data, isLoading: loading, error } = useQuery(
+    // This is the key for retrieving the data from react-query's cache;
+    // originally we were using the same key for this DAO query, no matter
+    // which DAO, but having an unique (but reproducible) key per DAO lets
+    // us store data on the user browser and persist it while avoiding
+    // false "info" flashes on other DAOs due to key collisions
+    `DAO_DATA_${daoAddress}`,
+    async () =>
+      request(
+        chainId === 4
+          ? env('RINKEBY_SUBGRAPH_URL')
+          : env('MAINNET_SUBGRAPH_URL'),
+        DAO_QUERY,
+        {
+          name: daoAddress,
+        },
+      ),
   )
 
   if (loading) {


### PR DESCRIPTION
Closes #241.

- Moves routing to have a parameter to track the network (`mainnet` or `rinkeby`)
- Introduces a redirect to the DAO Selector when the network is changed on the dropdown
- Introduces a home button (the logo on the top left, just like client.aragon.org)

_pls ignore that accidental push to master :D_