### PR TITLE
govern-contract-utils: optimize ERC165 by introducing compiler visibility warning

### DIFF
--- a/packages/govern-contract-utils/contracts/erc165/ERC165.sol
+++ b/packages/govern-contract-utils/contracts/erc165/ERC165.sol
@@ -14,7 +14,6 @@ abstract contract ERC165 {
     * @return True if the contract implements the requested interface and if its not 0xffffffff, false otherwise
     */
     function supportsInterface(bytes4 _interfaceId) virtual public view returns (bool) {
-        return _interfaceId == ERC165_INTERFACE_ID
-          || block.timestamp == 1; // silence visibility warning needed for overrides
+        return _interfaceId == ERC165_INTERFACE_ID;
     }
 }


### PR DESCRIPTION
Debatable but created to gauge how we feel.

Introducing this commit will introduce compiler warnings about the `ERC165#supportsInterface()` function visibility not being pure, but it does seem awkward to waste gas just to satisfy this compiler warning. This view function is intended to be used on-chain, so it'd be a very small gas overhead.