### PR TITLE
govern-contract-utils: ensure ACL is initialized with correct root account

### DIFF
--- a/packages/govern-contract-utils/contracts/acl/ACL.sol
+++ b/packages/govern-contract-utils/contracts/acl/ACL.sol
@@ -48,6 +48,8 @@ contract ACL is Initializable {
         // ACL might have been already initialized by constructors
         if (initBlocks["acl"] == 0) {
             _initializeACL(_initialRoot);
+        } else {
+            require(roles[ROOT_ROLE][_initialRoot] == ALLOW_FLAG, "acl: initial root misaligned");
         }
         _;
     }

--- a/packages/govern-core/contracts/Govern.sol
+++ b/packages/govern-core/contracts/Govern.sol
@@ -21,7 +21,7 @@ contract Govern is AdaptativeERC165, IERC3000Executor, ACL {
 
     event ETHDeposited(address indexed sender, uint256 value);
 
-    constructor(address _initialExecutor) ACL(address(this)) public {
+    constructor(address _initialExecutor) ACL(address(_initialExecutor)) public {
         initialize(_initialExecutor);
     }
 


### PR DESCRIPTION
Also debatable, but I found it weird that the initialization check would just get skipped if another constructor/function had already initialized the ACL. Particularly, I was afraid of a contract being statically or dynamically misconfigured such that two initialization areas contained different root grantees.