### PR TITLE
govern-contract-utils: lightly update DepositLib's event and error API

### DIFF
--- a/packages/govern-contract-utils/contracts/deposits/DepositLib.sol
+++ b/packages/govern-contract-utils/contracts/deposits/DepositLib.sol
@@ -11,24 +11,24 @@ import "../erc20/SafeERC20.sol";
 library DepositLib {
     using SafeERC20 for ERC20;
 
-    event Lock(address indexed token, address indexed from, uint256 amount);
-    event Unlock(address indexed token, address indexed to, uint256 amount);
+    event Locked(address indexed token, address indexed from, uint256 amount);
+    event Unlocked(address indexed token, address indexed to, uint256 amount);
 
     function collectFrom(ERC3000Data.Collateral memory _collateral, address _from) internal {
         if (_collateral.amount > 0) {
             ERC20 token = ERC20(_collateral.token);
-            require(token.safeTransferFrom(_from, address(this), _collateral.amount), "queue: bad get token");
+            require(token.safeTransferFrom(_from, address(this), _collateral.amount), "deposit: bad token lock");
 
-            emit Lock(_collateral.token, _from, _collateral.amount);
+            emit Locked(_collateral.token, _from, _collateral.amount);
         }
     }
 
     function releaseTo(ERC3000Data.Collateral memory _collateral, address _to) internal {
         if (_collateral.amount > 0) {
             ERC20 token = ERC20(_collateral.token);
-            require(token.safeTransfer(_to, _collateral.amount), "queue: bad send token");
+            require(token.safeTransfer(_to, _collateral.amount), "deposit: bad token release");
 
-            emit Unlock(_collateral.token, _to, _collateral.amount);
+            emit Unlocked(_collateral.token, _to, _collateral.amount);
         }
     }
 }


### PR DESCRIPTION
Generalizes `DepositLib` into the utils, and updates its events to fit the past-tense nomenclature of the other events.

Wasn't sure if we depended on this event anywhere else; as far as I could search there was nothing in a frontend, API, or subgraph package using these events or errors.