### PR TITLE
govern-contract-utils: fix ERC1167ProxyFactory#generateCode()

### DIFF
--- a/packages/govern-contract-utils/contracts/minimal-proxies/ERC1167ProxyFactory.sol
+++ b/packages/govern-contract-utils/contracts/minimal-proxies/ERC1167ProxyFactory.sol
@@ -8,10 +8,10 @@ pragma solidity ^0.6.8;
 
 library ERC1167ProxyFactory {
     function clone(address _implementation) internal returns (address cloneAddr) {
-        bytes memory code = generateCode(_implementation);
+        bytes memory createData = generateCreateData(_implementation);
 
         assembly {
-            cloneAddr := create(0, add(code, 0x20), 55)
+            cloneAddr := create(0, add(createData, 0x20), 55)
         }
         
         require(cloneAddr != address(0), "proxy-factory: bad create");
@@ -25,10 +25,10 @@ library ERC1167ProxyFactory {
     }
 
     function clone2(address _implementation, bytes32 _salt) internal returns (address cloneAddr) {
-        bytes memory code = generateCode(_implementation);
-        
+        bytes memory createData = generateCreateData(_implementation);
+
         assembly {
-            cloneAddr := create2(0, add(code, 0x20), 55, _salt)
+            cloneAddr := create2(0, add(createData, 0x20), 55, _salt)
         }
         
         require(cloneAddr != address(0), "proxy-factory: bad create2");
@@ -41,14 +41,15 @@ library ERC1167ProxyFactory {
         require(ok, _getRevertMsg(ret));
     }
 
-    function generateCode(address _implementation) internal pure returns (bytes memory code) {
-        code = new bytes(55);
-        
-        assembly {
-            mstore(add(code, 0x20), 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
-            mstore(add(code, 0x34), shl(0x60, _implementation))
-            mstore(add(code, 0x48), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
-        }
+    function generateCreateData(address _implementation) internal pure returns (bytes memory) {
+        return abi.encodePacked(
+            //---- constructor -----
+            bytes10(0x3d602d80600a3d3981f3),
+            //---- proxy code -----
+            bytes10(0x363d3d373d3d3d363d73),
+            _implementation,
+            bytes15(0x5af43d82803e903d91602b57fd5bf3)
+        );
     }
 
     // From: https://ethereum.stackexchange.com/a/83577

--- a/packages/govern-contract-utils/contracts/test/CloneFactoryMock.sol
+++ b/packages/govern-contract-utils/contracts/test/CloneFactoryMock.sol
@@ -15,7 +15,7 @@ contract CloneFactoryMock {
     address public cloningContractWithInit;
     address public latestClonedContract;
 
-    bytes public generatedCode;
+    bytes public generatedCreateData;
     string public revertMessage;
 
     constructor() public {
@@ -58,8 +58,8 @@ contract CloneFactoryMock {
         );
     }
 
-    function generateCode() public {
-        generatedCode = cloningContract.generateCode();
+    function generateCreateData() public {
+        generatedCreateData = cloningContract.generateCreateData();
     }
 
     function getRevertMessage(bytes memory _data) public {

--- a/packages/govern-contract-utils/test/erc1167-proxy-factory.test.ts
+++ b/packages/govern-contract-utils/test/erc1167-proxy-factory.test.ts
@@ -85,11 +85,12 @@ describe('ERC1167ProxyFactory', () => {
   })
 
   context('Helper methods', () => {
-    it.skip('calls "generateCode" as expected', async () => {
-      await factory.generateCode()
+    it('calls "generateCreateData" as expected', async () => {
+      const cloningContract = (await factory.cloningContract()).substring(2).toLowerCase()
+      await factory.generateCreateData()
 
-      expect(await factory.generatedCode())
-        .to.equal('0x3d602d80600a3d3981f3363d3d373d3d3d363d739467a509da43cb50eb332187602534991be1fea45af43d82803e903d91602b57fd5bf3')
+      expect(await factory.generatedCreateData())
+        .to.equal(`0x3d602d80600a3d3981f3363d3d373d3d3d363d73${cloningContract}5af43d82803e903d91602b57fd5bf3`)
     })
 
     it('calls "_getRevertMsg" with a revert message', async () => {


### PR DESCRIPTION
Fixes #239 (I think).

Updates how the data given to the `CREATE` opcode is generated, and verified output with the EIP in tests.