### PR TITLE
erc3k: use abi.encode() for hashing payload data

### DIFF
--- a/packages/erc3k/.solcover.js
+++ b/packages/erc3k/.solcover.js
@@ -1,0 +1,6 @@
+module.exports = {
+  mocha: {
+    grep: "@skip-on-coverage", // Find everything with this tag
+    invert: true               // Run the grep's inverse set.
+  }
+}

--- a/packages/erc3k/contracts/ERC3000Data.sol
+++ b/packages/erc3k/contracts/ERC3000Data.sol
@@ -59,7 +59,7 @@ library ERC3000Data {
 
     function hash(Payload memory payload) internal pure returns (bytes32) {
         return keccak256(
-            abi.encodePacked(
+            abi.encode(
                 payload.nonce,
                 payload.executionTime,
                 payload.submitter,

--- a/packages/erc3k/test/erc3k-data.test.ts
+++ b/packages/erc3k/test/erc3k-data.test.ts
@@ -115,7 +115,7 @@ describe('ERC3000Data', function () {
     )
   })
 
-  it('calls testContainerHash and returns the expected hash', async () => {
+  it('calls testContainerHash and returns the expected hash [ @skip-on-coverage ]', async () => {
     expect(await erc3kDataLib.testContainerHash(container)).to.be.equal(
       keccak256(
         solidityPack(

--- a/packages/erc3k/test/erc3k-data.test.ts
+++ b/packages/erc3k/test/erc3k-data.test.ts
@@ -35,35 +35,39 @@ let deposit = {
 
 function getPayloadHash(): string {
   return keccak256(
-    solidityPack(
+    defaultAbiCoder.encode(
       [
-        'uint256',
-        'uint256',
-        'address',
-        'address',
-        'bytes32',
-        'bytes32',
-        'bytes32',
+        'tuple(' +
+          'uint256 nonce, ' +
+          'uint256 executionTime, ' +
+          'address submitter, ' +
+          'address executor, ' +
+          'bytes32 actionHash, ' +
+          'bytes32 allowFailuresMap, ' +
+          'bytes32 proofBytes' +
+          ')',
       ],
       [
-        container.payload.nonce,
-        container.payload.executionTime,
-        container.payload.submitter,
-        container.payload.executor,
-        keccak256(
-          defaultAbiCoder.encode(
-            [
-              'tuple(' +
-                'address to, ' +
-                'uint256 value, ' +
-                'bytes data' +
-                ')[]',
-            ],
-            [container.payload.actions]
-          )
-        ),
-        container.payload.allowFailuresMap,
-        keccak256(container.payload.proof),
+        {
+          nonce: container.payload.nonce,
+          executionTime: container.payload.executionTime,
+          submitter: container.payload.submitter,
+          executor: container.payload.executor,
+          actionHash: keccak256(
+            defaultAbiCoder.encode(
+              [
+                'tuple(' +
+                  'address to, ' +
+                  'uint256 value, ' +
+                  'bytes data' +
+                  ')[]',
+              ],
+              [container.payload.actions]
+            )
+          ),
+          allowFailuresMap: container.payload.allowFailuresMap,
+          proofBytes: keccak256(container.payload.proof),
+        }
       ]
     )
   )
@@ -111,7 +115,7 @@ describe('ERC3000Data', function () {
     )
   })
 
-  it.skip('calls testContainerHash and returns the expected hash', async () => {
+  it('calls testContainerHash and returns the expected hash', async () => {
     expect(await erc3kDataLib.testContainerHash(container)).to.be.equal(
       keccak256(
         solidityPack(


### PR DESCRIPTION
Aligns the ABI encoding of `ERC3000Data`'s payload and config hashing.

These were misaligned in that hashing the payload struct used `abi.encodePacked()` whereas hashing the config struct used `abi.encode()`. I didn't see much reason to use `encodePacked()` for the payload (and for encoding structs, using the "standard" ABI encoding is generally preferred from what I've seen), but let me know otherwise.