### PR TITLE
govern-core, govern-contract-utils: rename AdaptativeERC165 to AdaptiveERC165

### DIFF
--- a/packages/govern-contract-utils/contracts/adaptive-erc165/AdaptiveERC165.sol
+++ b/packages/govern-contract-utils/contracts/adaptive-erc165/AdaptiveERC165.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.6.8;
 
 import "../erc165/ERC165.sol";
 
-contract AdaptativeERC165 is ERC165 {
+contract AdaptiveERC165 is ERC165 {
     // ERC165 interface ID -> whether it is supported
     mapping (bytes4 => bool) internal standardSupported;
     // Callback function signature -> magic number to return

--- a/packages/govern-core/contracts/Govern.sol
+++ b/packages/govern-core/contracts/Govern.sol
@@ -9,10 +9,10 @@ import "erc3k/contracts/IERC3000Executor.sol";
 import "erc3k/contracts/IERC3000.sol";
 
 import "@aragon/govern-contract-utils/contracts/acl/ACL.sol";
-import "@aragon/govern-contract-utils/contracts/adaptative-erc165/AdaptativeERC165.sol";
+import "@aragon/govern-contract-utils/contracts/adaptive-erc165/AdaptiveERC165.sol";
 import "@aragon/govern-contract-utils/contracts/bitmaps/BitmapLib.sol";
 
-contract Govern is IERC3000Executor, AdaptativeERC165, ACL {
+contract Govern is IERC3000Executor, AdaptiveERC165, ACL {
     using BitmapLib for bytes32;
 
     bytes4 internal constant EXEC_ROLE = this.exec.selector;

--- a/packages/govern-core/contracts/pipelines/GovernQueue.sol
+++ b/packages/govern-core/contracts/pipelines/GovernQueue.sol
@@ -10,7 +10,7 @@ import "erc3k/contracts/IERC3000.sol";
 import "@aragon/govern-contract-utils/contracts/protocol/IArbitrable.sol";
 import "@aragon/govern-contract-utils/contracts/deposits/DepositLib.sol";
 import "@aragon/govern-contract-utils/contracts/acl/ACL.sol";
-import "@aragon/govern-contract-utils/contracts/adaptative-erc165/AdaptativeERC165.sol";
+import "@aragon/govern-contract-utils/contracts/adaptive-erc165/AdaptiveERC165.sol";
 import "@aragon/govern-contract-utils/contracts/erc20/SafeERC20.sol";
 
 library GovernQueueStateLib {
@@ -42,7 +42,7 @@ library GovernQueueStateLib {
     }
 }
 
-contract GovernQueue is IERC3000, IArbitrable, AdaptativeERC165, ACL {
+contract GovernQueue is IERC3000, IArbitrable, AdaptiveERC165, ACL {
     // Syntax sugar to enable method-calling syntax on types
     using ERC3000Data for *;
     using DepositLib for ERC3000Data.Collateral;


### PR DESCRIPTION
"Adaptative" is not a word :)