### PR TITLE
govern-core: set initial register role to Govern instance

### DIFF
--- a/packages/govern-core/contracts/Govern.sol
+++ b/packages/govern-core/contracts/Govern.sol
@@ -27,7 +27,7 @@ contract Govern is IERC3000Executor, AdaptiveERC165, ACL {
 
     function initialize(address _initialExecutor) public initACL(address(this)) onlyInit("govern") {
         _grant(EXEC_ROLE, address(_initialExecutor));
-        _grant(REGISTER_ROLE, address(_initialExecutor));
+        _grant(REGISTER_ROLE, address(this));
         _registerStandard(ERC3000_EXEC_INTERFACE_ID);
     }
 


### PR DESCRIPTION
Similar to #257, I think the intent was to set the `REGISTER_ROLE` to the Govern instance itself, rather than the executor (e.g. if it was a `GovernQueue`, it'd never be able to access the `registerStandardAndCallback()` functionality.

Leaving as draft as I'm not sure if there are any thoughts on how to best modify the now failing test.