### PR TITLE
CI/CD: Revert of accidentally merged PRs or updating of tests

### DIFF
--- a/packages/govern-core/contracts/Govern.sol
+++ b/packages/govern-core/contracts/Govern.sol
@@ -32,7 +32,7 @@ contract Govern is IERC3000Executor, AdaptiveERC165, ERC1271, ACL {
 
     function initialize(address _initialExecutor) public initACL(address(this)) onlyInit("govern") {
         _grant(EXEC_ROLE, address(_initialExecutor));
-        _grant(REGISTER_STANDARD_ROLE, address(this));
+        _grant(REGISTER_STANDARD_ROLE, address(_initialExecutor));
         _grant(SET_SIGNATURE_VALIDATOR_ROLE, address(this));
 
         _registerStandard(ERC3000_EXEC_INTERFACE_ID);

--- a/packages/govern-subgraph/subgraph.template.yaml
+++ b/packages/govern-subgraph/subgraph.template.yaml
@@ -46,8 +46,8 @@ templates:
           handler: handleResolved
         - event: Revoked(indexed bytes4,indexed address,indexed address)
           handler: handleRevoked
-        - event: EvidenceSubmitted(indexed address,indexed uint256,indexed address,bytes,bool)
-          handler: handleEvidenceSubmitted
+        #- event: EvidenceSubmitted(indexed address,indexed uint256,indexed address,bytes,bool)
+        #  handler: handleEvidenceSubmitted
         - event: Ruled(indexed address,indexed uint256,uint256)
           handler: handleRuled
       file: ./src/GovernQueue.ts


### PR DESCRIPTION
This PR does highlight the problems we have currently with our CI/CD. In the case of the broken subgraph did I just out-comment the registration of the event handler. To actually fix the subgraph is another PR required with a well-defined scope.

The Problems:

- PR #259 got merged without discussing the proposed changes or at least adjusting the tests 
- The ``IArbitrable`` interface got adjusted to reflect Aragon Protocol v2. This means the ``Arbitrable`` does no longer have the ``EvidenceSubmitted`` event. This event is now within the ``DisputeManager``. 
    - @0xGabi Means we would have to add the ``DisputeManager`` to the subgraph of Govern and listen there for the events. 


Would be great if we could discuss here the changes which did get merged without a real review or without updating the Govern Framework on the points the changes did have an impact on.