### PR TITLE
remove evidenceSubmitted event

### DIFF
--- a/packages/govern-subgraph/README.md
+++ b/packages/govern-subgraph/README.md
@@ -125,7 +125,6 @@ Tracked:
 - `Vetoed`
 - `Resolved`
 - `Revoked`
-- `EvidenceSubmitted`
 - `Ruled`
 
 Left out: None.

--- a/packages/govern-subgraph/src/GovernQueue.ts
+++ b/packages/govern-subgraph/src/GovernQueue.ts
@@ -145,26 +145,6 @@ export function handleConfigured(event: ConfiguredEvent): void {
   queue.save()
 }
 
-// IArbitrable Events
-
-
-
-export function handleRuled(event: RuledEvent): void {
-  // let governQueue = GovernQueueContract.bind(event.address)
-  // let containerHash = governQueue.disputeItemCache(
-  //   event.params.arbitrator,
-  //   event.params.disputeId
-  // )
-  // let container = loadOrCreateContainer(containerHash)
-
-  // container.state =
-  //   event.params.ruling === ALLOW_RULING ? APPROVED_STATUS : REJECTED_STATUS
-
-  // handleContainerEventRule(container, event)
-
-  // container.save()
-}
-
 // MiniACL Events
 
 export function handleFrozen(event: FrozenEvent): void {

--- a/packages/govern-subgraph/src/GovernQueue.ts
+++ b/packages/govern-subgraph/src/GovernQueue.ts
@@ -10,7 +10,6 @@ import {
   Scheduled as ScheduledEvent,
   Vetoed as VetoedEvent,
   Ruled as RuledEvent,
-  EvidenceSubmitted as EvidenceSubmittedEvent,
   GovernQueue as GovernQueueContract
 } from '../generated/templates/GovernQueue/GovernQueue'
 import {
@@ -38,7 +37,6 @@ import {
   handleContainerEventResolve,
   handleContainerEventRule,
   handleContainerEventSchedule,
-  handleContainerEventSubmitEvidence,
   handleContainerEventVeto
 } from './utils/events'
 
@@ -95,7 +93,7 @@ export function handleChallenged(event: ChallengedEvent): void {
 export function handleResolved(event: ResolvedEvent): void {
   let container = loadOrCreateContainer(event.params.containerHash)
 
-  container.state = event.params.approved ? EXECUTED_STATUS : CANCELLED_STATUS
+  container.state = event.params.approved ? APPROVED_STATUS : REJECTED_STATUS
 
   handleContainerEventResolve(container, event)
 
@@ -149,31 +147,22 @@ export function handleConfigured(event: ConfiguredEvent): void {
 
 // IArbitrable Events
 
-export function handleEvidenceSubmitted(event: EvidenceSubmittedEvent): void {
-  let governQueue = GovernQueueContract.bind(event.address)
-  let containerHash = governQueue.disputeItemCache(
-    event.params.arbitrator,
-    event.params.disputeId
-  )
-  let container = loadOrCreateContainer(containerHash)
 
-  handleContainerEventSubmitEvidence(container, event)
-}
 
 export function handleRuled(event: RuledEvent): void {
-  let governQueue = GovernQueueContract.bind(event.address)
-  let containerHash = governQueue.disputeItemCache(
-    event.params.arbitrator,
-    event.params.disputeId
-  )
-  let container = loadOrCreateContainer(containerHash)
+  // let governQueue = GovernQueueContract.bind(event.address)
+  // let containerHash = governQueue.disputeItemCache(
+  //   event.params.arbitrator,
+  //   event.params.disputeId
+  // )
+  // let container = loadOrCreateContainer(containerHash)
 
-  container.state =
-    event.params.ruling === ALLOW_RULING ? APPROVED_STATUS : REJECTED_STATUS
+  // container.state =
+  //   event.params.ruling === ALLOW_RULING ? APPROVED_STATUS : REJECTED_STATUS
 
-  handleContainerEventRule(container, event)
+  // handleContainerEventRule(container, event)
 
-  container.save()
+  // container.save()
 }
 
 // MiniACL Events

--- a/packages/govern-subgraph/src/utils/events.ts
+++ b/packages/govern-subgraph/src/utils/events.ts
@@ -15,7 +15,6 @@ import {
   Resolved as ResolvedEvent,
   Ruled as RuledEvent,
   Scheduled as ScheduledEvent,
-  EvidenceSubmitted as EvidenceSubmittedEvent,
   Vetoed as VetoedEvent
 } from '../../generated/templates/GovernQueue/GovernQueue'
 import { buildId, buildIndexedId, buildEventHandlerId } from './ids'
@@ -131,22 +130,7 @@ export function handleContainerEventSchedule(
   )
 }
 
-export function handleContainerEventSubmitEvidence(
-  container: ContainerEntity,
-  ethereumEvent: EvidenceSubmittedEvent
-): ContainerEventSubmitEvidenceEntity {
-  let eventId = buildEventHandlerId(container.id, 'submitEvidence', ethereumEvent.transactionLogIndex.toHexString())
 
-  let containerEvent = new ContainerEventSubmitEvidenceEntity(eventId)
-  containerEvent.evidence = ethereumEvent.params.evidence
-  containerEvent.submitter = ethereumEvent.params.submitter
-  containerEvent.finished = ethereumEvent.params.finished
-
-  return finalizeContainerEvent<
-    EvidenceSubmittedEvent,
-    ContainerEventSubmitEvidenceEntity
-  >(container, containerEvent, ethereumEvent)
-}
 
 export function handleContainerEventVeto(
   container: ContainerEntity,

--- a/packages/govern-subgraph/subgraph.template.yaml
+++ b/packages/govern-subgraph/subgraph.template.yaml
@@ -46,8 +46,6 @@ templates:
           handler: handleResolved
         - event: Revoked(indexed bytes4,indexed address,indexed address)
           handler: handleRevoked
-        - event: Ruled(indexed address,indexed uint256,uint256)
-          handler: handleRuled
       file: ./src/GovernQueue.ts
   - kind: ethereum/contract
     name: Govern

--- a/packages/govern-subgraph/subgraph.template.yaml
+++ b/packages/govern-subgraph/subgraph.template.yaml
@@ -46,8 +46,6 @@ templates:
           handler: handleResolved
         - event: Revoked(indexed bytes4,indexed address,indexed address)
           handler: handleRevoked
-        - event: EvidenceSubmitted(indexed address,indexed uint256,indexed address,bytes,bool)
-          handler: handleEvidenceSubmitted
         - event: Ruled(indexed address,indexed uint256,uint256)
           handler: handleRuled
       file: ./src/GovernQueue.ts


### PR DESCRIPTION
This removes `evidenceSubmitted` event since it's been removed from the `IArbitrable` and is now moved to `DisputeManager`. 

Also, there's `handleRuled` mapping which was doing the following:

```
let containerHash = governQueue.disputeItemCache(
   event.params.arbitrator,
   event.params.disputeId
)
```


`disputeItemCache` has been changed and now expects arguments as `containerHash` and `disputeId`.. The `Ruled` event, though, doesn't emit `containerHash`, so it's impossible to grab the container.  

So, this also removes `handleRuled` mapping and event. What `handleRuled` intended to do is now done by `handleResolved`.


