### PR TITLE
fix govern test for registerStandardAndCallback

### DIFF
--- a/packages/govern-core/test/govern.test.ts
+++ b/packages/govern-core/test/govern.test.ts
@@ -59,11 +59,19 @@ describe('Govern', function() {
     const magicNumber = '0x10000000'
     const callbackSig = hexDataSlice(id('callbackFunc()'), 0, 4)
 
+    const calldata = govern.interface.encodeFunctionData("registerStandardAndCallback", [callbackSig, callbackSig, magicNumber]);
+
+    const action = {
+      to:govern.address,
+      value: 0,
+      data: calldata
+    };
+
     await expect(
-      govern.registerStandardAndCallback(
-        callbackSig,
-        callbackSig,
-        magicNumber
+      govern.exec(
+        [action],
+        B32_ZERO,
+        B32_ZERO
       )
     )
       .to.emit(govern, EVENTS.REGISTERED_STANDARD)


### PR DESCRIPTION
This presumably fixes #259 where the test case for `registerStandardAndCallback` was failing since the function can be only called by `Govern` itself.