### PR TITLE
fix apply ruling for default value

### DIFF
--- a/packages/govern-core/contracts/pipelines/GovernQueue.sol
+++ b/packages/govern-core/contracts/pipelines/GovernQueue.sol
@@ -180,7 +180,7 @@ contract GovernQueue is IERC3000, IArbitrable, AdaptiveERC165, ACL {
         arbitrator.submitEvidence(disputeId, msg.sender, _reason);
         arbitrator.closeEvidencePeriod(disputeId);
 
-        disputeItemCache[containerHash][arbitrator] = disputeId; // cache a relation between disputeId and containerHash while needed
+        disputeItemCache[containerHash][arbitrator] = disputeId + 1; // cache a relation between disputeId and containerHash while needed
 
         emit Challenged(containerHash, msg.sender, _reason, disputeId, collateral);
     }
@@ -195,7 +195,7 @@ contract GovernQueue is IERC3000, IArbitrable, AdaptiveERC165, ACL {
         bytes32 containerHash = _container.hash();
         IArbitrator arbitrator = IArbitrator(_container.config.resolver);
 
-        require(disputeItemCache[containerHash][arbitrator] == _disputeId, "queue: bad dispute id");
+        require(disputeItemCache[containerHash][arbitrator] == _disputeId + 1, "queue: bad dispute id");
         delete disputeItemCache[containerHash][arbitrator]; // release state to refund gas; no longer needed in state
 
         queue[containerHash].checkState(GovernQueueStateLib.State.Challenged);


### PR DESCRIPTION
The default value of `disputeItemCache[containerHash][arbitrator]` if the `containerHash` and `arbitrator` don't exist, is 0. This means that if we call `resolve` on the `c2` container where `c2` is not challenged and pass 0, as `disputeId`, the below check would succeed, which is wrong.

```
require(disputeItemCache[containerHash][arbitrator] == _disputeId, "queue: bad dispute id");
```

To fix,  we store `disputeId + 1` in the `disputeItemCache`  on the `challenge` function and add `disputeId + 1` check in the `resolve`'s require check.

```
require(disputeItemCache[containerHash][arbitrator] == _disputeId + 1, "queue: bad dispute id");
```


 If we call the `resolve` on unchallenged container `c2`, and pass 0 as `disputeId`, it would now check if the `disputeItemCache[containerHash][arbitrator] == 1` which would be false.

**NOTE**: NOT SURE THOUGH: Since arbitrator can be anything else, other than Aragon Protocol and `disputeId` can be returned maliciously, It might be worth using `safeMath` for adding `+1`. 

