### PR TITLE
addressutils tests + fix isContract

### DIFF
--- a/packages/govern-contract-utils/contracts/address-utils/AddressUtils.sol
+++ b/packages/govern-contract-utils/contracts/address-utils/AddressUtils.sol
@@ -5,6 +5,7 @@
 pragma solidity ^0.6.8;
 
 library AddressUtils {
+    
     function toPayable(address addr) internal pure returns (address payable) {
         return address(bytes20(addr));
     }
@@ -23,7 +24,7 @@ library AddressUtils {
      */
     function isContract(address addr) internal view returns (bool result) {
         assembly {
-            result := not(iszero(extcodesize(addr)))
+            result := iszero(iszero(extcodesize(addr)))
         }
     }
 }

--- a/packages/govern-contract-utils/contracts/erc20/SafeERC20.sol
+++ b/packages/govern-contract-utils/contracts/erc20/SafeERC20.sol
@@ -50,7 +50,7 @@ library SafeERC20 {
                 case 0x20 {
                     // Only return success if returned data was true
                     // Already have output in ptr
-                    ret := not(iszero(mload(ptr)))
+                    ret := iszero(iszero(mload(ptr)))
                 }
 
                 // Not sure what was returned: don't mark as success

--- a/packages/govern-contract-utils/contracts/test/AddressUtilsMock.sol
+++ b/packages/govern-contract-utils/contracts/test/AddressUtilsMock.sol
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier:    GPL-3.0
+ */
+
+pragma solidity 0.6.8;
+
+import "../address-utils/AddressUtils.sol";
+
+contract AddressUtilsMock {
+
+    using AddressUtils for address;
+    
+    function toPayable(address _addr) external pure returns(address) {
+        return _addr.toPayable();
+    }
+
+    function isContract(address _addr) external view returns(bool){
+        return _addr.isContract();
+    }
+    
+}
+
+

--- a/packages/govern-contract-utils/test/address-utils.test.ts
+++ b/packages/govern-contract-utils/test/address-utils.test.ts
@@ -1,0 +1,32 @@
+import { expect } from 'chai'
+import { ethers } from 'hardhat'
+import {
+  AddressUtilsMock,
+  AddressUtilsMock__factory
+} from '../typechain'
+
+
+describe('AddressUtils', function () {
+  let addressUtils: AddressUtilsMock
+  let owner: any;
+
+  beforeEach(async () => {
+    const AddressUtilsMock = (await ethers.getContractFactory('AddressUtilsMock')) as AddressUtilsMock__factory
+    addressUtils = await AddressUtilsMock.deploy()
+    owner = await (await ethers.getSigners())[0].getAddress()
+  })
+
+  it('returns false if the address is not the contract', async () => {
+    expect(await addressUtils.isContract(owner)).to.equal(false);
+  })
+
+  it('returns true if the address is the contract', async () => {
+    expect(await addressUtils.isContract(addressUtils.address)).to.equal(true);
+  })
+
+  it('returns the same address that was passed', async () => {
+    expect(await addressUtils.toPayable(owner)).to.equal(owner);   
+  })
+
+})
+

--- a/packages/govern-contract-utils/tsconfig.json
+++ b/packages/govern-contract-utils/tsconfig.json
@@ -11,5 +11,3 @@
   "include": ["hardhat.config.ts", "./test"]
 }
 
-
-  

--- a/packages/govern-contract-utils/tsconfig.json
+++ b/packages/govern-contract-utils/tsconfig.json
@@ -1,13 +1,15 @@
 {
-    "compilerOptions": {
-      "target": "es5",
-      "module": "commonjs",
-      "strict": true,
-      "esModuleInterop": true,
-      "moduleResolution": "node",
-      "forceConsistentCasingInFileNames": true,
-      "outDir": "dist"
-    },
-    "include": ["hardhat.config.ts", "./test"]
-  }
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["hardhat.config.ts", "./test"]
+}
+
+
   

--- a/packages/govern-contract-utils/tsconfig.json
+++ b/packages/govern-contract-utils/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+      "target": "es5",
+      "module": "commonjs",
+      "strict": true,
+      "esModuleInterop": true,
+      "moduleResolution": "node",
+      "forceConsistentCasingInFileNames": true,
+      "outDir": "dist"
+    },
+    "include": ["hardhat.config.ts", "./test"]
+  }
+  


### PR DESCRIPTION
It seems like the code was using `not` assembly instruction for the 2 things.

* ```not(iszero(mload(ptr)))```
* ```not(iszero(extcodesize(addr)))```

The idea is that both of the equations above get assigned to `bool` variables. `not` is not the NOT operator. It's a bitwise `NOT` operator of `x`, which means `not(1)` won't be 0, which means that the above 2 are not correct.

We change them to be:

* ```iszero(iszero(mload(ptr)))```
* ```iszero(iszero(extcodesize(addr)))```

@nivida  Thanks to Sam for discussing this with me too.

@izqui your thoughts ? 

Fixes #114 