### PR TITLE
chore(govern-create): add optional param to `deploy-govern`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ To use Govern, feel free to deploy your own registries and factories, but using 
 
 #### Rinkeby
 
-- 📜 GovernRegistry: [`0x87eE5EA31dCf1f526f21Bb576131C37890AE65E0`](https://rinkeby.etherscan.io/address/0x87eE5EA31dCf1f526f21Bb576131C37890AE65E0)
-- 🏭 GovernBaseFactory: [`0x615e3d83B8e1403c39F98c7066faA1D9bBF9E867`](https://rinkeby.etherscan.io/address/0x615e3d83B8e1403c39F98c7066faA1D9bBF9E867)
+- 📜 GovernRegistry: [`0x8adf949adbab3614f5340b21d9d9ad928d218096`](https://rinkeby.etherscan.io/address/0x8adf949adbab3614f5340b21d9d9ad928d218096)
+- 🏭 GovernBaseFactory: [`0x1791E1D949c21703f49FC2C9a24570FA72ed62Ae`](https://rinkeby.etherscan.io/address/0x1791E1D949c21703f49FC2C9a24570FA72ed62Ae)
 
 ## Help shape Aragon Govern
 - Discuss in [Aragon Forum](https://forum.aragon.org/tags/aragon-govern)

--- a/packages/govern-create/tasks/govern.ts
+++ b/packages/govern-create/tasks/govern.ts
@@ -25,12 +25,14 @@ const format = (address: string, name: string, network: string): string =>
   }etherscan.io/address/${address}`
 
 task('deploy-govern', 'Deploys a Govern instance')
+  .addOptionalParam('registry', 'GovernRegistry address')
   .addOptionalParam('factory', 'GovernBaseFactory address')
   .addOptionalParam('useProxies', 'Whether to deploy govern with proxies')
   .addOptionalParam('name', 'DAO name (must be unique at GovernRegistry level)')
   .setAction(
     async (
       {
+        registry,
         factory,
         useProxies = true,
         name,
@@ -43,11 +45,12 @@ task('deploy-govern', 'Deploys a Govern instance')
       name = buildName(name)
       const { ethers, deployments, network } = HRE
 
-      const registryDeployment = await deployments.get('GovernRegistry')
-      const registryContract = await ethers.getContractAt(
-        'GovernRegistry',
-        registryDeployment.address
-      )
+      const registryContract = registry
+      ? await ethers.getContractAt('GovernRegistry', registry)
+      : await ethers.getContractAt(
+          'GovernRegistry',
+          (await deployments.get('GovernRegistry')).address
+        )
 
       const baseFactoryContract = factory
         ? await ethers.getContractAt('GovernBaseFactory', factory)


### PR DESCRIPTION
This PR adds an optional parameter to the `deploy-govern` hardhat task in order to allow specifying not only the factory but also the registry.

Btw, I hope you don't mind I updated the Rinkeby addresses (those that are being tracked by the [Subgraph](https://thegraph.com/explorer/subgraph/aragon/aragon-govern-rinkeby) instance).