### PR TITLE
ARA2-81: specify port to connect to postgres

### DIFF
--- a/packages/govern-server/docker-compose.yml
+++ b/packages/govern-server/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - ganache
     environment:
       postgres_host: postgres
+      postgres_port: 5432
       postgres_user: graph-node
       postgres_pass: let-me-in
       postgres_db: graph-node


### PR DESCRIPTION
This is to fix graph-node container failed to connect to postgres when running locally.