### PR TITLE
fix null value issue with registryEntry query

### DIFF
--- a/packages/govern-subgraph/src/GovernRegistry.ts
+++ b/packages/govern-subgraph/src/GovernRegistry.ts
@@ -12,9 +12,17 @@ import {
   RegistryEntry as RegistryEntryEntity
 } from '../generated/schema'
 import { loadOrCreateGovern } from './Govern'
+import { loadOrCreateQueue } from './GovernQueue'
 
 export function handleRegistered(event: RegisteredEvent): void {
   let registry = loadOrCreateRegistry(event.address)
+
+  // create and save these to avoid null error from
+  // registryEntries queries due to missing data
+  let queue = loadOrCreateQueue(event.params.queue)
+  let govern = loadOrCreateGovern(event.params.executor)
+  queue.save()
+  govern.save()
 
   let registryEntry = new RegistryEntryEntity(event.params.name)
 

--- a/packages/govern-subgraph/src/utils/constants.ts
+++ b/packages/govern-subgraph/src/utils/constants.ts
@@ -1,4 +1,4 @@
-import { BigInt } from '@graphprotocol/graph-ts'
+import { BigInt, Bytes } from '@graphprotocol/graph-ts'
 
 export const APPROVED_STATUS = 'Approved'
 export const CANCELLED_STATUS = 'Cancelled'
@@ -9,3 +9,5 @@ export const REJECTED_STATUS = 'Rejected'
 export const SCHEDULED_STATUS = 'Scheduled'
 
 export let ALLOW_RULING = BigInt.fromI32(4)
+
+export let ZERO_ADDRESS = Bytes.fromHexString("0x0000000000000000000000000000000000000000") as Bytes


### PR DESCRIPTION
This is to fix the error from RegistryEntry subgraph query error:


```
Null value resolved for non-null field `queue`
```

The way to reproduce this issue is to registry a Dao (call contract GovernRegistry.register()) with an invalid GovernQueue address.

If the name is 'M', then the following subgraph query will give the null error.
```
registryEntry(id: "M") {
      id
      name
    queue {
      id
    }
      
  }
```

Govern does not have the problem because the register() function has a call to _setMetadata() which trigger an event and trigger the subgraph to instantiate the `executor` entity.

@novaknole , I'm not sure if I need to add GovernQueue in the data source entity here after this change:
https://github.com/aragon/govern/blob/master/packages/govern-subgraph/manifest/templates/contracts/GovernRegistry.template.yaml#L13

Doesn't give me any error without adding that to the entities field.
