### PR TITLE
Subgraph null executor error

### DIFF
--- a/packages/govern-subgraph/src/GovernQueue.ts
+++ b/packages/govern-subgraph/src/GovernQueue.ts
@@ -40,19 +40,20 @@ import {
   handleContainerEventSchedule,
   handleContainerEventVeto
 } from './utils/events'
-
+import { loadOrCreateGovern } from './Govern'
 
 export function handleScheduled(event: ScheduledEvent): void {
   let queue = loadOrCreateQueue(event.address)
   let payload = loadOrCreatePayload(event.params.containerHash)
   let container = loadOrCreateContainer(event.params.containerHash)
+  let executor = loadOrCreateGovern(event.params.payload.executor)
   // Builds each of the actions bundled in the payload,
   // and saves them to the DB.
   buildActions(event)
   payload.nonce = event.params.payload.nonce
   payload.executionTime = event.params.payload.executionTime
   payload.submitter = event.params.payload.submitter
-  payload.executor = event.params.payload.executor.toHex()
+  payload.executor = executor.id
   payload.allowFailuresMap = event.params.payload.allowFailuresMap
   payload.proof = event.params.payload.proof
 

--- a/packages/govern-subgraph/src/GovernQueue.ts
+++ b/packages/govern-subgraph/src/GovernQueue.ts
@@ -68,6 +68,7 @@ export function handleScheduled(event: ScheduledEvent): void {
 
   handleContainerEventSchedule(container, event, scheduleDeposit as CollateralEntity)
 
+  executor.save()
   payload.save()
   container.save()
   queue.save()


### PR DESCRIPTION
This PR is for issue [86](https://linear.app/aragon/issue/ARA2-86/console-failed-to-load-dao-due-to-subgraph-null-error)

Created an issue [87](https://linear.app/aragon/issue/ARA2-87/add-tests-for-subgraph-query) to add automated test for this issue.

Manually tested the fix using this query on https://thegraph.com/explorer/subgraph/yuetloo/aragon-govern-v2-rinkeby

```
{
    registryEntry(id: "comprehensive-beige") {
      executor {
        id
      }
    	queue {
        queued {
          payload {
            nonce
            executor {
              id
            }
          }
        }
      }
    }
  }
  ```