### PR TITLE
add gitbook content configuration file

### DIFF
--- a/.gitbook.yml
+++ b/.gitbook.yml
@@ -1,0 +1,1 @@
+root: ./docs


### PR DESCRIPTION
This PR addresses the issue https://linear.app/aragon/issue/MAN-53/update-govern-documentation.

The issue was the .gitbook.yml was missing from the repository, gitbook ended up generating the content with all the README files from all the projects in the repository.  By providing the .gitbook.yml file, we're telling gitbook to look for the documentation in the docs folder.

