### PR TITLE
change token amount to BigNumberish

### DIFF
--- a/packages/govern/public/createDao.ts
+++ b/packages/govern/public/createDao.ts
@@ -1,6 +1,7 @@
 import { Contract } from '@ethersproject/contracts'
 import { Web3Provider, TransactionResponse } from '@ethersproject/providers'
 import { AddressZero } from '@ethersproject/constants'
+import { BigNumberish } from '@ethersproject/bignumber'
 import Configuration from '../internal/configuration/Configuration'
 
 export const ContainerConfig = `tuple(uint256 executionDelay, tuple(address token, uint256 amount) scheduleDeposit, tuple(address token, uint256 amount) challengeDeposit, address resolver, bytes rules, uint256 maxCalldataSize)`
@@ -28,11 +29,11 @@ export type DaoConfig = {
   executionDelay: number
   scheduleDeposit: {
     token: string
-    amount: number
+    amount: BigNumberish
   }
   challengeDeposit: {
     token: string
-    amount: number
+    amount: BigNumberish
   }
   resolver: string
   rules: string


### PR DESCRIPTION
This fix is needed because token amount can be larger than javascript's number.

And, when we do any math on the token amount, we need to use BigNumber operations on them.. i.e. 
```
   BigNumber.from(token.amount).add(anotherAmount)
```

