### PR TITLE
fix test failure with big numbers

### DIFF
--- a/packages/govern-core/test/chai-utils/equal-overwrite.ts
+++ b/packages/govern-core/test/chai-utils/equal-overwrite.ts
@@ -22,7 +22,7 @@ const deepEqual = ( actual: any, expected: any ): boolean => {
   }
 
   // compare BigNumbers
-  if( actual instanceof BigNumber ) {
+  if( BigNumber.isBigNumber(actual) ) {
     return actual.eq(expected);
   }
 
@@ -41,8 +41,9 @@ export function equalOverwrite(Assertion: Chai.AssertionStatic, utils: Chai.Chai
 
       if( Array.isArray(actual) ) {
         this.assert(deepEqual(actual, expected), 
-          `Expected value does not equal actual value`, 
-          actual.toString(), 
+          `Expected ${expected} to equal ${actual}`,
+          '',
+          actual,
           expected
         );
       } else {


### PR DESCRIPTION
This addresses issue: https://linear.app/aragon/issue/DAO-200/coverage-for-govern-core-fails-only-on-github-workflow

`BigNumber.isBigNumber(val)` is used to check for big numbers now as this works with the current version of ethers.js library in govern-core.