### PR TITLE
executor needs to be set before the effect is being returned.

### DIFF
--- a/packages/govern-console/src/containers/NewProposal/NewProposal.tsx
+++ b/packages/govern-console/src/containers/NewProposal/NewProposal.tsx
@@ -182,8 +182,8 @@ const NewProposal: React.FC<NewProposalProps> = ({ onClickBack, ...props }) => {
 
   const proposal = React.useMemo(() => {
     if (daoDetails) {
-      return new Proposal(daoDetails.queue.address, proposalOptions);
       executor = daoDetails.executor.address;
+      return new Proposal(daoDetails.queue.address, proposalOptions);
     }
   }, [daoDetails]);
 


### PR DESCRIPTION
Executor was being set after a return statement causing an unreachable code. 
This was the reason which might have caused the invalid ENS name. 

I have moved it up.