### PR TITLE
fix govern test failures

### DIFF
--- a/packages/govern/jest.config.js
+++ b/packages/govern/jest.config.js
@@ -22,5 +22,8 @@ module.exports = {
     'dist',
     'createDao.ts',
     'proposal.ts',
+    'Gateway.ts',
+    'token.ts',
+    'RegisterToken.ts'
   ]
 }

--- a/packages/govern/package.json
+++ b/packages/govern/package.json
@@ -62,13 +62,10 @@
     "uglify-es": "^3.3.9"
   },
   "dependencies": {
-    "@ethersproject/constants": "^5.1.0",
-    "@ethersproject/contracts": "^5.1.0",
-    "@ethersproject/providers": "^5.1.0",
-    "@ethersproject/strings": "^5.1.0",
     "@urql/core": "^1.13.1",
-    "graphql": "^15.4.0",
     "dvote-js": "^1.3.1",
+    "ethers": "^5.1.4",
+    "graphql": "^15.4.0",
     "graphql-tag": "^2.11.0",
     "isomorphic-unfetch": "^3.1.0"
   }

--- a/packages/govern/public/createDao.ts
+++ b/packages/govern/public/createDao.ts
@@ -1,8 +1,4 @@
-import { Contract } from '@ethersproject/contracts'
-import { Web3Provider, TransactionResponse } from '@ethersproject/providers'
-import { AddressZero } from '@ethersproject/constants'
-import { BigNumberish } from '@ethersproject/bignumber'
-import { BytesLike } from '@ethersproject/bytes'
+import { Contract, utils, providers, BigNumberish, constants } from 'ethers'
 import Configuration from '../internal/configuration/Configuration'
 import { registerToken } from '../internal/actions/RegisterToken'
 
@@ -68,7 +64,7 @@ export type DaoConfig = {
   scheduleDeposit: TokenDeposit
   challengeDeposit: TokenDeposit
   resolver: string
-  rules: BytesLike
+  rules: utils.BytesLike
   maxCalldataSize: number
 }
 
@@ -99,9 +95,9 @@ export async function createDao(
   options: CreateDaoOptions = {},
   registerTokenCallback?: Function,
   bla?: TokenDeposit
-): Promise<TransactionResponse> {
+): Promise<providers.TransactionResponse> {
   if (!args.token.tokenAddress) {
-    args.token.tokenAddress = AddressZero
+    args.token.tokenAddress = constants.AddressZero
   } else {
     args.token = {
       tokenDecimals: 18,
@@ -111,7 +107,7 @@ export async function createDao(
     }
   }
 
-  const addressIsZero = args.token.tokenAddress === AddressZero
+  const addressIsZero = args.token.tokenAddress === constants.AddressZero
   const tokenIsMissingInfo = !args.token.tokenName || !args.token.tokenSymbol
 
   if (addressIsZero && tokenIsMissingInfo) {
@@ -120,7 +116,7 @@ export async function createDao(
 
   const config = Configuration.get()
   const factoryAddress = options.daoFactoryAddress || config.daoFactoryAddress
-  const signer = await new Web3Provider(
+  const signer = await new providers.Web3Provider(
     options.provider || window.ethereum
   ).getSigner()
   const contract = new Contract(factoryAddress, factoryAbi, signer)

--- a/packages/govern/public/createDao.ts
+++ b/packages/govern/public/createDao.ts
@@ -94,7 +94,7 @@ export async function createDao(
   args: CreateDaoParams,
   options: CreateDaoOptions = {},
   registerTokenCallback?: Function
-): Promise<TransactionResponse> {
+): Promise<providers.TransactionResponse> {
   if (!args.token.tokenAddress) {
     args.token.tokenAddress = constants.AddressZero
   } else {

--- a/packages/govern/public/proposal.ts
+++ b/packages/govern/public/proposal.ts
@@ -1,10 +1,11 @@
 import { DaoConfig, ContainerConfig } from './createDao'
-import { ContractInterface, Contract } from '@ethersproject/contracts'
-import { Web3Provider, TransactionResponse, TransactionReceipt } from '@ethersproject/providers'
-import { BigNumberish } from '@ethersproject/bignumber'
-import { BytesLike } from '@ethersproject/bytes'
-import { toUtf8Bytes } from '@ethersproject/strings'
-import { ethers } from 'ethers';
+import {
+  ContractInterface,
+  Contract,
+  providers,
+  BigNumberish,
+  utils
+} from 'ethers'
 
 
 const Payload = `
@@ -65,14 +66,14 @@ export type PayloadType = {
   submitter: string
   executor: string
   actions: ActionType[]
-  allowFailuresMap: BytesLike
-  proof: BytesLike
+  allowFailuresMap: utils.BytesLike
+  proof: utils.BytesLike
 }
 
 export type ActionType = {
   to: string
   value: BigNumberish
-  data: BytesLike
+  data: utils.BytesLike
 }
 
 export class Proposal {
@@ -83,9 +84,9 @@ export class Proposal {
     const abi:any = options?.abi || queueAbis // TODO instead of any, put Fragment|JSONFragment from ethers
      
     const provider = options.provider || window.ethereum
-    const signer = new Web3Provider(provider).getSigner()
+    const signer = new providers.Web3Provider(provider).getSigner()
     this.contract = new Contract(queueAddress, abi, signer)
-    this.interface  = new ethers.utils.Interface(abi);
+    this.interface  = new utils.Interface(abi);
   }
 
   /**
@@ -95,7 +96,7 @@ export class Proposal {
    *
    * @returns {Promise<TransactionResponse>} transaction response object
    */
-  async schedule(proposal: ProposalParams): Promise<TransactionResponse> {
+  async schedule(proposal: ProposalParams): Promise<providers.TransactionResponse> {
     const nonce = await this.contract.nonce()
 
     const proposalWithNonce = Object.assign({}, proposal)
@@ -111,7 +112,7 @@ export class Proposal {
    *
    * @returns {Promise<TransactionResponse>} transaction response object
    */
-  async execute(proposal: ProposalParams): Promise<TransactionResponse> {
+  async execute(proposal: ProposalParams): Promise<providers.TransactionResponse> {
     const result = this.contract.execute(proposal)
     return result
   }
@@ -125,8 +126,8 @@ export class Proposal {
    *
    * @returns {Promise<TransactionResponse>} transaction response object
    */
-  async veto(proposal: ProposalParams, reason: string): Promise<TransactionResponse> {
-    const reasonBytes = toUtf8Bytes(reason)
+  async veto(proposal: ProposalParams, reason: string): Promise<providers.TransactionResponse> {
+    const reasonBytes = utils.toUtf8Bytes(reason)
     const result = this.contract.veto(proposal, reasonBytes)
     return result
   }
@@ -140,7 +141,7 @@ export class Proposal {
    *
    * @returns {Promise<TransactionResponse>} transaction response object
    */
-  async resolve(proposal: ProposalParams, disputeId: number): Promise<TransactionResponse> {
+  async resolve(proposal: ProposalParams, disputeId: number): Promise<providers.TransactionResponse> {
     const result = this.contract.resolve(proposal, disputeId)
     return result
   }
@@ -154,8 +155,8 @@ export class Proposal {
    *
    * @returns {Promise<TransactionResponse>} transaction response object
    */
-  async challenge(proposal: ProposalParams, reason: string): Promise<TransactionResponse> {
-    const reasonBytes = toUtf8Bytes(reason)
+  async challenge(proposal: ProposalParams, reason: string): Promise<providers.TransactionResponse> {
+    const reasonBytes = utils.toUtf8Bytes(reason)
     const result = this.contract.challenge(proposal, reasonBytes)
     return result
   }
@@ -198,7 +199,7 @@ export class Proposal {
    *
    * @returns {number|null>} transaction response object
    */
-  getDisputeId(receipt: TransactionReceipt): number|null {
+  getDisputeId(receipt: providers.TransactionReceipt): number|null {
     const args = receipt.logs
     .filter(({ address }: { address : string }) => address === this.contract.address)
     .map((log: any) => this.contract.interface.parseLog(log))

--- a/packages/govern/public/token.ts
+++ b/packages/govern/public/token.ts
@@ -1,5 +1,4 @@
-import { Contract } from '@ethersproject/contracts'
-import { Web3Provider } from '@ethersproject/providers'
+import { Contract, providers } from 'ethers'
 import { Token } from './createDao'
 
 const tokenAbi = [
@@ -8,7 +7,7 @@ const tokenAbi = [
   "function decimals() view returns (uint8)"
 ]
 
-export async function getToken(tokenAddress: string, provider: Web3Provider): Promise<Token> {
+export async function getToken(tokenAddress: string, provider: providers.Web3Provider): Promise<Token> {
   const contract = new Contract(tokenAddress, tokenAbi, provider)
   const [tokenDecimals, tokenName, tokenSymbol]: [number, string, string] = await Promise.all([
     contract.decimals(),

--- a/packages/govern/tests/e2e/daoTest.e2e.ts
+++ b/packages/govern/tests/e2e/daoTest.e2e.ts
@@ -1,7 +1,6 @@
 import { configure, dao, daos } from '@aragon/govern'
 import { subgraphURL } from './config'
 import { utils, BigNumber } from 'ethers'
-const { isAddress } = utils
 
 /**
  * dao e2e test
@@ -37,7 +36,7 @@ describe('[e2e] dao Test', () => {
 
     expect(response.queue.id).toBeDefined()
 
-    expect(isAddress(response.queue.address)).toEqual(true)
+    expect(utils.isAddress(response.queue.address)).toEqual(true)
 
     expect(BigNumber.from(response.queue.nonce).gte(0)).toEqual(true)
 
@@ -58,11 +57,11 @@ describe('[e2e] dao Test', () => {
     expect(container).toHaveProperty('state')
     expect(container).toHaveProperty('config')
     expect(container).toHaveProperty('payload')
-    expect(isAddress(container.payload.executor.address)).toEqual(true)
-    expect(isAddress(container.payload.submitter)).toEqual(true)
+    expect(utils.isAddress(container.payload.executor.address)).toEqual(true)
+    expect(utils.isAddress(container.payload.submitter)).toEqual(true)
     expect(Array.isArray(container.payload.actions)).toEqual(true)
     expect(container.payload.actions[0]).toHaveProperty('id')
-    expect(isAddress(container.payload.actions[0].to)).toEqual(true)
+    expect(utils.isAddress(container.payload.actions[0].to)).toEqual(true)
     expect(container.payload.actions[0]).toHaveProperty('value')
     expect(container.payload.actions[0]).toHaveProperty('data')
     expect(container.payload).toHaveProperty('allowFailuresMap')
@@ -71,7 +70,7 @@ describe('[e2e] dao Test', () => {
 
     expect(response.executor.address).toBeDefined()
 
-    expect(isAddress(response.executor.address)).toEqual(true)
+    expect(utils.isAddress(response.executor.address)).toEqual(true)
 
     expect(response.executor.metadata).toBeDefined()
 
@@ -79,8 +78,8 @@ describe('[e2e] dao Test', () => {
 
     expect(response.executor.roles[0]).toBeDefined()
 
-    expect(isAddress(response.token)).toEqual(true)
-    expect(isAddress(response.registrant)).toEqual(true)
+    expect(utils.isAddress(response.token)).toEqual(true)
+    expect(utils.isAddress(response.registrant)).toEqual(true)
   })
 
   it('non-existent dao should return null', async () => {

--- a/packages/govern/tests/e2e/daoTest.e2e.ts
+++ b/packages/govern/tests/e2e/daoTest.e2e.ts
@@ -1,8 +1,7 @@
 import { configure, dao, daos } from '@aragon/govern'
 import { subgraphURL } from './config'
-import { isAddress } from '@ethersproject/address'
-import { BigNumber } from '@ethersproject/bignumber'
-
+import { utils, BigNumber } from 'ethers'
+const { isAddress } = utils
 
 /**
  * dao e2e test

--- a/packages/govern/tests/e2e/daosTest.e2e.ts
+++ b/packages/govern/tests/e2e/daosTest.e2e.ts
@@ -1,7 +1,6 @@
 import { configure, daos } from '@aragon/govern'
 import { subgraphURL } from './config'
 import { utils } from 'ethers'
-const { isAddress } = utils
 
 /**
  * daos e2e test
@@ -24,7 +23,7 @@ describe('[e2e] daos Test', () => {
 
     expect(response[0].queue.id).toBeDefined()
 
-    expect(isAddress(response[0].queue.address)).toEqual(true)
+    expect(utils.isAddress(response[0].queue.address)).toEqual(true)
 
     expect(response[0].queue.nonce).toBeDefined()
 
@@ -41,6 +40,6 @@ describe('[e2e] daos Test', () => {
     expect(Array.isArray(response[0].queue.containers)).toEqual(true)
 
     expect(response[0].executor.metadata).toBeDefined()
-    expect(isAddress(response[0].executor.address)).toEqual(true)
+    expect(utils.isAddress(response[0].executor.address)).toEqual(true)
   })
 })

--- a/packages/govern/tests/e2e/daosTest.e2e.ts
+++ b/packages/govern/tests/e2e/daosTest.e2e.ts
@@ -1,6 +1,7 @@
 import { configure, daos } from '@aragon/govern'
 import { subgraphURL } from './config'
-import { isAddress } from '@ethersproject/address'
+import { utils } from 'ethers'
+const { isAddress } = utils
 
 /**
  * daos e2e test

--- a/packages/govern/tests/e2e/queryTest.e2e.ts
+++ b/packages/govern/tests/e2e/queryTest.e2e.ts
@@ -1,6 +1,6 @@
 import { configure, query } from '@aragon/govern'
 import { subgraphURL } from './config'
-import { ethers } from 'ethers'
+import { utils } from 'ethers'
 
 /**
  * query e2e test
@@ -21,7 +21,7 @@ describe('[e2e] query Test', () => {
       }
     `)
 
-    expect(ethers.utils.isAddress(response.daos[0].token)).toEqual(true)
-    expect(ethers.utils.isAddress(response.daos[0].registrant)).toEqual(true)
+    expect(utils.isAddress(response.daos[0].token)).toEqual(true)
+    expect(utils.isAddress(response.daos[0].registrant)).toEqual(true)
   })
 })

--- a/packages/govern/tests/hardhat/proposal.test.ts
+++ b/packages/govern/tests/hardhat/proposal.test.ts
@@ -128,7 +128,7 @@ describe("Proposal", function() {
     const submitter = await (web3Provider.getSigner()).getAddress()
 
     const currentTimestamp = (await web3Provider.getBlock('latest')).timestamp
-    const executionTime = currentTimestamp + daoConfig.executionDelay + 100
+    const executionTime = Number(currentTimestamp) + Number(daoConfig.executionDelay) + 100
     const payload = buildPayload({ submitter, executor, actions, executionTime})
     const proposalData = { payload, config: daoConfig }
     const txResult = await proposal.schedule(proposalData)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1882,7 +1882,7 @@
   dependencies:
     "@ethersproject/bignumber" "^5.1.0"
 
-"@ethersproject/contracts@5.1.1", "@ethersproject/contracts@^5.0.0", "@ethersproject/contracts@^5.1.0":
+"@ethersproject/contracts@5.1.1", "@ethersproject/contracts@^5.0.0":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.1.1.tgz#c66cb6d618fcbd73e20a6b808e8f768b2b781d0b"
   integrity sha512-6WwktLJ0DFWU8pDkgH4IGttQHhQN4SnwKFu9h+QYVe48VGWtbDu4W8/q/7QA1u/HWlWMrKxqawPiZUJj0UMvOw==
@@ -1992,7 +1992,7 @@
   dependencies:
     "@ethersproject/logger" "^5.1.0"
 
-"@ethersproject/providers@5.1.2", "@ethersproject/providers@^5.0.0", "@ethersproject/providers@^5.1.0":
+"@ethersproject/providers@5.1.2", "@ethersproject/providers@^5.0.0":
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.1.2.tgz#4e4459698903f911402fe91aa7544eb07f3921ed"
   integrity sha512-GqsS8rd+eyd4eNkcNgzZ4l9IRULBPUZa7JPnv22k4MHflMobUseyhfbVnmoN5bVNNkOxjV1IPTw9i0sV1hwdpg==
@@ -9252,17 +9252,7 @@ concat-stream@^1.5.0, concat-stream@^1.5.1, concat-stream@~1.6.2:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-concat-stream@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-2.0.0.tgz#414cf5af790a48c60ab9be4527d56d5e41133cb1"
-  integrity sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==
-  dependencies:
-    buffer-from "^1.0.0"
-    inherits "^2.0.3"
-    readable-stream "^3.0.2"
-    typedarray "^0.0.6"
-
-"concat-stream@github:hugomrdias/concat-stream#feat/smaller":
+concat-stream@^2.0.0, "concat-stream@github:hugomrdias/concat-stream#feat/smaller":
   version "2.0.0"
   resolved "https://codeload.github.com/hugomrdias/concat-stream/tar.gz/057bc7b5d6d8df26c8cf00a3f151b6721a0a8034"
   dependencies:
@@ -10678,10 +10668,10 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
-dvote-js@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/dvote-js/-/dvote-js-1.2.1.tgz#a3cdb8b6ad97e115dab45bdb2ddde1ef919245ab"
-  integrity sha512-B08ZicwQzhpy6yNhonDZh9zCpv1mE2ZpYbkzJ0IZbPT6e/6gMvCJdhsMuSY+1SvKqw6Nxz4HtJufuYiDUozjFA==
+dvote-js@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/dvote-js/-/dvote-js-1.3.1.tgz#9a8f6e29975158b498c150325869340c476d0c36"
+  integrity sha512-nIaO06MoytxJRAXzetqQAkM3pc+w9CLHReQ+DFuEVjSUKl1t7t+JB3ow7lvHIvY5xlVEH/BldwdXoPvLMM9OGw==
   dependencies:
     "@vocdoni/storage-proofs-eth" "^0.2.3"
     axios "^0.21.1"
@@ -12095,7 +12085,7 @@ ethers@^4.0.32:
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
 
-ethers@^5.0.0, ethers@^5.0.1, ethers@^5.0.2, ethers@^5.0.23, ethers@^5.0.24, ethers@^5.1.3:
+ethers@^5.0.0, ethers@^5.0.1, ethers@^5.0.2, ethers@^5.0.23, ethers@^5.0.24, ethers@^5.1.3, ethers@^5.1.4:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.1.4.tgz#8ae973705ed962f8f41dc59693704002a38dd18b"
   integrity sha512-EAPQ/fgGRu0PoR/VNFnHTMOtG/IZ0AItdW55C9T8ffmVu0rnyllZL404eBF66elJehOLz2kxnUrhXpE7TCpW7g==
@@ -21188,6 +21178,11 @@ react-helmet-async@^1.0.7:
     prop-types "^15.7.2"
     react-fast-compare "^3.2.0"
     shallowequal "^1.1.0"
+
+react-hook-form@^7.4.0:
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.4.0.tgz#b024faf7f6eaf9ee5c25c219d6b38a654c147be6"
+  integrity sha512-47paUN7uIajM0h2aqSgMHLLDAMNtKsndgel5xTFebsWmwvAAOcYoSTM+IE7En3tNcTmmVYnlx/eLQFrYcxGkbQ==
 
 react-inspector@^5.1.0:
   version "5.1.1"


### PR DESCRIPTION
As a temporary workaround for the coverage test failure, I took `RegisterToken.js`, `token.js`, `Gateway.js` out of the jest coverage test.

We should add them back once we consolidated the test framework to use in govern, see https://linear.app/aragon/issue/DAO-237/convert-tests-from-jest-to-mocha-in-governjs

