### PR TITLE
force refresh of proposal page

### DIFF
--- a/packages/govern-console/src/containers/DAO/DaoMainPage.tsx
+++ b/packages/govern-console/src/containers/DAO/DaoMainPage.tsx
@@ -139,7 +139,7 @@ const DaoMainPage: React.FC<{
       error: proposalErrors,
       fetchMore: fetchMoreProposals,
     },
-  ] = useLazyQuery(GET_PROPOSAL_LIST);
+  ] = useLazyQuery(GET_PROPOSAL_LIST, { fetchPolicy: 'no-cache' });
 
   const fetchMoreData = async () => {
     if (fetchMoreProposals) {


### PR DESCRIPTION
@reddyismav I only apply the no-cache policy to the query to retrieve proposals. I didn't do it for the get_dao_by_name query as it doesn't appear to be that the data from get_dao_by_name that are displayed on the proposals page can be changed.

Just want you to double check and make sure it's ok.