### PR TITLE
DAO-369: use network-concurrency 1 to workaround govern build error

### DIFF
--- a/.github/workflows/govern-console-ci-cd.yml
+++ b/.github/workflows/govern-console-ci-cd.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           node-version: 14.15.5
       - name: Build the Govern
-        run: cd ../govern && yarn install --frozen-lockfile && yarn build
+        run: cd ../govern && yarn install --frozen-lockfile --network-concurrency 1 && yarn build
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build the app


### PR DESCRIPTION
Since the test in this job https://github.com/aragon/govern/runs/3885381908?check_suite_focus=true went pass the build step, failing on the fleek step, I'm creating this PR to fix the build error we saw in govern build.