### PR TITLE
Subgraph error

### DIFF
--- a/packages/govern-subgraph/src/GovernQueue.ts
+++ b/packages/govern-subgraph/src/GovernQueue.ts
@@ -1,11 +1,4 @@
-import {
-  Address,
-  Bytes,
-  BigInt,
-  ipfs,
-  json,
-  log
-} from '@graphprotocol/graph-ts'
+import { Address, Bytes, BigInt, ipfs, json, log } from '@graphprotocol/graph-ts'
 import {
   Challenged as ChallengedEvent,
   Configured as ConfiguredEvent,
@@ -19,7 +12,7 @@ import {
 } from '../generated/templates/GovernQueue/GovernQueue'
 
 import { GovernQueue as GovernQueueContract } from '../generated/templates/GovernQueue/GovernQueue'
-import { getERC20Info } from './utils/tokens'
+import { getERC20Info } from './utils/tokens';
 
 import {
   Action,
@@ -68,10 +61,10 @@ export function handleScheduled(event: ScheduledEvent): void {
   payload.proof = event.params.payload.proof
 
   let proofIpfsHex = event.params.payload.proof.toHexString().substring(2)
-
+  
   // if cidString is ipfs v1 version hex from the cid's raw bytes and
   // we add `f` as a multibase prefix and remove `0x`
-  let result = ipfs.cat('f' + proofIpfsHex + '/metadata.json')
+  let result = ipfs.cat('f' + proofIpfsHex + "/metadata.json")
   if (!result) {
     // if cidString is ipfs v0 version hex from the cid's raw bytes,
     // we add:
@@ -107,7 +100,6 @@ export function handleScheduled(event: ScheduledEvent): void {
 }
 
 export function handleExecuted(event: ExecutedEvent): void {
-  log.debug('executed event params {}', [event.params.containerHash.toString()])
   let container = loadOrCreateContainer(event.params.containerHash)
   container.state = EXECUTED_STATUS
   container.save()
@@ -169,15 +161,15 @@ export function handleConfigured(event: ConfiguredEvent): void {
 
   // Grab Schedule Token info
   let data = getERC20Info(event.params.config.scheduleDeposit.token)
-  scheduleDeposit.decimals = data.decimals
-  scheduleDeposit.name = data.name
-  scheduleDeposit.symbol = data.symbol
+  scheduleDeposit.decimals = data.decimals;
+  scheduleDeposit.name = data.name;
+  scheduleDeposit.symbol = data.symbol;
 
   // Grab challenge Token info
   data = getERC20Info(event.params.config.challengeDeposit.token)
-  challengeDeposit.decimals = data.decimals
-  challengeDeposit.name = data.name
-  challengeDeposit.symbol = data.symbol
+  challengeDeposit.decimals = data.decimals;
+  challengeDeposit.name = data.name;
+  challengeDeposit.symbol = data.symbol;
 
   config.executionDelay = event.params.config.executionDelay
   config.scheduleDeposit = scheduleDeposit.id
@@ -278,19 +270,9 @@ export function loadOrCreateContainer(containerHash: Bytes): Container {
   let ContainerId = containerHash.toHex()
   // Create container
   let container = Container.load(ContainerId)
-
   if (container === null) {
-    log.debug('container is null, createing new container with id ', [
-      ContainerId
-    ])
     container = new Container(ContainerId)
     container.state = NONE_STATUS
-  } else {
-    log.debug('container is NOT null for id {}', [ContainerId])
-    if (container.queue === null) {
-      log.debug('container queue is null, setting a zero address', [])
-      container.queue = '0x0000000000000000000000000000000000000000'
-    }
   }
   return container!
 }

--- a/packages/govern-subgraph/src/GovernQueue.ts
+++ b/packages/govern-subgraph/src/GovernQueue.ts
@@ -1,4 +1,11 @@
-import { Address, Bytes, BigInt, ipfs, json, log } from '@graphprotocol/graph-ts'
+import {
+  Address,
+  Bytes,
+  BigInt,
+  ipfs,
+  json,
+  log
+} from '@graphprotocol/graph-ts'
 import {
   Challenged as ChallengedEvent,
   Configured as ConfiguredEvent,
@@ -12,7 +19,7 @@ import {
 } from '../generated/templates/GovernQueue/GovernQueue'
 
 import { GovernQueue as GovernQueueContract } from '../generated/templates/GovernQueue/GovernQueue'
-import { getERC20Info } from './utils/tokens';
+import { getERC20Info } from './utils/tokens'
 
 import {
   Action,
@@ -61,10 +68,10 @@ export function handleScheduled(event: ScheduledEvent): void {
   payload.proof = event.params.payload.proof
 
   let proofIpfsHex = event.params.payload.proof.toHexString().substring(2)
-  
+
   // if cidString is ipfs v1 version hex from the cid's raw bytes and
   // we add `f` as a multibase prefix and remove `0x`
-  let result = ipfs.cat('f' + proofIpfsHex + "/metadata.json")
+  let result = ipfs.cat('f' + proofIpfsHex + '/metadata.json')
   if (!result) {
     // if cidString is ipfs v0 version hex from the cid's raw bytes,
     // we add:
@@ -100,6 +107,7 @@ export function handleScheduled(event: ScheduledEvent): void {
 }
 
 export function handleExecuted(event: ExecutedEvent): void {
+  log.debug('executed event params {}', [event.params.containerHash.toString()])
   let container = loadOrCreateContainer(event.params.containerHash)
   container.state = EXECUTED_STATUS
   container.save()
@@ -161,15 +169,15 @@ export function handleConfigured(event: ConfiguredEvent): void {
 
   // Grab Schedule Token info
   let data = getERC20Info(event.params.config.scheduleDeposit.token)
-  scheduleDeposit.decimals = data.decimals;
-  scheduleDeposit.name = data.name;
-  scheduleDeposit.symbol = data.symbol;
+  scheduleDeposit.decimals = data.decimals
+  scheduleDeposit.name = data.name
+  scheduleDeposit.symbol = data.symbol
 
   // Grab challenge Token info
   data = getERC20Info(event.params.config.challengeDeposit.token)
-  challengeDeposit.decimals = data.decimals;
-  challengeDeposit.name = data.name;
-  challengeDeposit.symbol = data.symbol;
+  challengeDeposit.decimals = data.decimals
+  challengeDeposit.name = data.name
+  challengeDeposit.symbol = data.symbol
 
   config.executionDelay = event.params.config.executionDelay
   config.scheduleDeposit = scheduleDeposit.id
@@ -270,9 +278,19 @@ export function loadOrCreateContainer(containerHash: Bytes): Container {
   let ContainerId = containerHash.toHex()
   // Create container
   let container = Container.load(ContainerId)
+
   if (container === null) {
+    log.debug('container is null, createing new container with id ', [
+      ContainerId
+    ])
     container = new Container(ContainerId)
     container.state = NONE_STATUS
+  } else {
+    log.debug('container is NOT null for id {}', [ContainerId])
+    if (container.queue === null) {
+      log.debug('container queue is null, setting a zero address', [])
+      container.queue = '0x0000000000000000000000000000000000000000'
+    }
   }
   return container!
 }

--- a/packages/govern-subgraph/src/utils/events.ts
+++ b/packages/govern-subgraph/src/utils/events.ts
@@ -6,7 +6,7 @@ import {
   ContainerEventResolve,
   ContainerEventRule,
   ContainerEventSchedule,
-  ContainerEventVeto,
+  ContainerEventVeto
 } from '../../generated/schema'
 import { Executed as ExecutedEvent } from '../../generated/templates/Govern/Govern'
 import {
@@ -14,7 +14,7 @@ import {
   Resolved as ResolvedEvent,
   Ruled as RuledEvent,
   Scheduled as ScheduledEvent,
-  Vetoed as VetoedEvent,
+  Vetoed as VetoedEvent
 } from '../../generated/templates/GovernQueue/GovernQueue'
 import { buildId, buildEventHandlerId } from './ids'
 import { Bytes } from '@graphprotocol/graph-ts'
@@ -27,7 +27,6 @@ function finalizeContainerEvent<T, U>(
   containerEvent.createdAt = ethereumEvent.block.timestamp
   containerEvent.container = container.id
 
-  container.save()
   containerEvent.save()
 
   return containerEvent


### PR DESCRIPTION
This fixes the following error which caused the govern subgraph to fail to sync. 

```
Entity Container[0x0000000000000000000000000000000000000000000000000000000000000000]: missing value for non-nullable field `queue`\twasm backtrace:\t    0: 0x167c - <unknown>!generated/schema/Container#save\t    1: 0x16e2 - <unknown>!src/utils/events/finalizeContainerEvent<generated/templates/Govern/Govern/Executed,generated/schema/ContainerEventExecute>\t    2: 0x1727 - <unknown>!src/utils/events/handleContainerEventExecute\t    3: 0x1792 - <unknown>!src/Govern/handleExecuted\t
```

More investigation is required to understand how to populate the queue information (if required) when the govern `exec` method is called.

By simply removing the `save()` line, the subgraph will not throw because `queue` was not populated for the newly created container.  And, the `save()` line is not required because the code path does not modify the `container` object, so, no need to save.

However, `finalizeContainerEvent` is called in other event handlers and those handlers change the container object. I checked all those handlers and they do save container after modifying it.. I don't know if those events would have a case that produces container without queue.