### PR TITLE
save user input without transformation

### DIFF
--- a/packages/govern-console/src/components/ActionBuilder/ActionInputText.tsx
+++ b/packages/govern-console/src/components/ActionBuilder/ActionInputText.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { TextInput } from '@aragon/ui';
 import { Control, FieldValues, useController } from 'react-hook-form';
 
@@ -15,26 +15,22 @@ const ActionInputText: React.FC<ActionInputTextProps> = ({
   actionIndex,
   formControl,
 }) => {
-  const [value, setValue] = useState<string | null>();
   const { field: controllerField, fieldState: controllerFieldState } = useController({
     name: `actions.${actionIndex}.inputs.${inputNum}.value`,
     control: formControl,
+    defaultValue: '',
     rules: {
       required: 'This is required.',
     },
   });
 
-  useEffect(() => {
-    if (value) {
-      controllerField.onChange(`0x${Buffer.from(value).toString('hex')}`);
-    }
-  }, [value, controllerField]);
-
   return (
     <TextInput
       wide
-      value={value}
-      onChange={(event: React.ChangeEvent<HTMLInputElement>) => setValue(event.target.value)}
+      value={controllerField.value}
+      onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+        controllerField.onChange(event.target.value)
+      }
       subtitle={input.name}
       placeholder={input.type}
       status={controllerFieldState.error ? 'error' : 'normal'}


### PR DESCRIPTION
@sepehr2github , the reason for the invalid address because the logic that transforms user input.  I removed the transformation. But, I don't know why it's added in the first place, so, this PR breaks that change.  It's better to figure out why before merging this change into the develop branch.