### PR TITLE
fix: switchout ipfs endpoint with ours

### DIFF
--- a/packages/govern-console/src/utils/ipfs.tsx
+++ b/packages/govern-console/src/utils/ipfs.tsx
@@ -16,9 +16,9 @@ const MIME_TYPES = ['text/plain'];
 function createIpfs() {
   if (!ipfs) {
     ipfs = create({
-      url: 'https://2a7143fae39e7adaeb57.b-cdn.net/api/v0',
+      url: 'https://ipfs-0.aragon.network/api/v0',
       headers: {
-        authorization: 'v2 z7fAEdRSjqiH7Qv8ez2Qs6gypd5v3YH8cPGEE9MyESMVb',
+        'X-API-KEY': 'yRERPRwFAb5ZiV94XvJdgvDKoGEeFerfFsAQ65',
       },
     });
   }


### PR DESCRIPTION
The previously used IPFS endpoint stopped working.
This pull request switches the used IPFS endpoint to an Aragon owned which exposes certain API endpoints of IPFS in a more secure way